### PR TITLE
Osgifying String Template

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -6,13 +6,15 @@
     <property name="build.dir" value="${basedir}/build" />
     <property name="lib.dir" value="${basedir}/lib" />
     <property name="install.root.dir" value="${dist.dir}/ST-${version}" />
+    <property name="osgi.file" value="${basedir}/osgi.bnd" />
 
     <property name="jar.file" value="${dist.dir}/ST-${version}.jar" />
+    <property name="bnd.jar" value="/usr/local/lib/biz.aQute.bnd.jar" />
 
 	<path id="classpath">
         <pathelement location="/usr/local/lib/antlr-3.4-complete.jar"/> <!-- parrt setup -->
         <pathelement location="${antlr3.jar}"/> <!-- general setup -->
-		<pathelement location="${ant-antlr3.jar}"/>
+	<pathelement location="${ant-antlr3.jar}"/>
 	</path>
 
     <target name="clean">
@@ -62,18 +64,19 @@
     </target>
 
     <target name="build-jar" depends="compile" description="Build ST4.jar">
-        <mkdir dir="${dist.dir}"/>
+	<mkdir dir="${dist.dir}" />
+	<replace file="${osgi.file}" token="@version@" value="${version}" />
+	<taskdef resource="aQute/bnd/ant/taskdef.properties" classpath="${bnd.jar}" />
+	<bnd
+		classpath="${build.dir}/classes/"
+		failok="false"
+		exceptions="true"
+		files="${osgi.file}"
+		output="${jar.file}"
+	/>
+</target>
 
-        <jar jarfile="${jar.file}">
-            <fileset dir="${build.dir}/classes" includes="**/*.class"/>
-
-            <manifest>
-                <attribute name="Version" value="${version}"/>
-            </manifest>
-        </jar>
-    </target>
-
-    <target name="zip-source" depends="compile">
+<target name="zip-source" depends="compile">
         <mkdir dir="${install.root.dir}"/>
 
         <mkdir dir="${install.root.dir}/src"/>

--- a/osgi.bnd
+++ b/osgi.bnd
@@ -1,0 +1,21 @@
+Export-Package: *
+Bundle-Version: @version@
+Bundle-Description: StringTemplate is a java template engine for generating source code,\
+web pages, emails, or any other formatted text output.\
+\
+StringTemplate is particularly good at multi-targeted code generators,\
+multiple site skins, and internationalization/localization. \
+\
+It evolved over years of effort developing jGuru.com. \
+\
+StringTemplate also generates the stringtemplate website: http://www.stringtemplate.org\
+and powers the ANTLR v3 code generator. Its distinguishing characteristic \
+is that unlike other engines, it strictly enforces model-view separation.\
+\
+Strict separation makes websites and code generators more flexible\
+and maintainable; it also provides an excellent defense against malicious\
+template authors.\
+\
+There are currently about 600 StringTemplate source downloads a month.
+Bundle-License: http://antlr.org/license.html
+Bundle-SymbolicName: org.antlr.ST4

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.antlr</groupId>
     <artifactId>ST4</artifactId>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
 
     <!--
         The version number defined here in the version tag indicates how the
@@ -239,6 +239,18 @@ There are currently about 600 StringTemplate source downloads a month.
 						</goals>
 					</execution>
 				</executions>
+			</plugin>
+			
+		<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+				<version>2.3.6</version>
+				<configuration>
+					<instructions>
+						<Import-Package>org.stringtemplate.v4,org.stringtemplate.v4.misc,org.stringtemplate.v4.debug,*</Import-Package>
+					</instructions>
+				</configuration>
 			</plugin>
 	</plugins>
     </build>


### PR DESCRIPTION
Create proper OSGi bundles for String Template. These changes will enable the creation of a jar that can be used inside an OSGi environment as a proper bundle. In a maven build, you can simply do install, however for ant, the bnd jar tool must live inside your /usr/local/lib directory.

More information about the bnd tool here:

http://www.aqute.biz/Bnd/Bnd

The bnd jar can be downloaded from:

http://dl.dropbox.com/u/2590603/bnd/biz.aQute.bnd.jar

Source code:

https://github.com/bndtools/bnd
