### PR TITLE
Import of relative dir in JAR is not working

### DIFF
--- a/src/org/stringtemplate/v4/misc/Misc.java
+++ b/src/org/stringtemplate/v4/misc/Misc.java
@@ -167,14 +167,20 @@ public class Misc {
 	}
 
 	public static boolean urlExists(URL url) {
+		InputStream is = null;
 		try {
 			URLConnection con = url.openConnection();
-			InputStream is = con.getInputStream();
-			is.close();
+			is = con.getInputStream();
 			return true;
 		}
 		catch (IOException ioe) {
 			return false;
+		} finally {
+			try {
+				is.close();
+			} catch (NullPointerException npe) {
+			} catch (IOException e) {
+			}
 		}
 	}
 


### PR DESCRIPTION
When you try to import a dir relative to a group file which is loaded from a JAR, you get an NPE when closing the `InputStream` at `org.stringtemplate.v4.misc.Misc.urlExists(URL)`. This is a problem with the JDK, the same problem is described here: https://jira.springsource.org/browse/SPR-1629

My solution here is to put the close of the `InputStream` into a new finally block, swallowing all relevant  exceptions.
