### PR TITLE
Type safety of AttributeRenderer and ModelAdaptor

### DIFF
--- a/src/org/stringtemplate/v4/AttributeRenderer.java
+++ b/src/org/stringtemplate/v4/AttributeRenderer.java
@@ -42,6 +42,6 @@ import java.util.Locale;
  * {@code formatString} can be {@code null} but {@code locale} will at least be
  * {@link Locale#getDefault}.</p>
  */
-public interface AttributeRenderer {
-    public String toString(Object o, String formatString, Locale locale);
+public interface AttributeRenderer<T> {
+    public String toString(T o, String formatString, Locale locale);
 }

--- a/src/org/stringtemplate/v4/CalendarRenderer.java
+++ b/src/org/stringtemplate/v4/CalendarRenderer.java
@@ -1,0 +1,13 @@
+package org.stringtemplate.v4;
+
+import java.util.Calendar;
+import java.util.Locale;
+
+public class CalendarRenderer implements AttributeRenderer<Calendar> {
+    private final DateRenderer delegate = new DateRenderer();
+    
+    @Override
+    public String toString(Calendar o, String formatString, Locale locale) {
+        return delegate.toString(o.getTime(), formatString, locale);
+    }
+}

--- a/src/org/stringtemplate/v4/DateRenderer.java
+++ b/src/org/stringtemplate/v4/DateRenderer.java
@@ -37,7 +37,7 @@ import java.util.*;
  * assumes {@code "short"} format. A prefix of {@code "date:"} or
  * {@code "time:"} shows only those components of the time object.
  */
-public class DateRenderer implements AttributeRenderer {
+public class DateRenderer implements AttributeRenderer<Date> {
     public static final Map<String,Integer> formatToInt =
         new HashMap<String,Integer>() {
             {
@@ -59,11 +59,8 @@ public class DateRenderer implements AttributeRenderer {
         };
 
 	@Override
-    public String toString(Object o, String formatString, Locale locale) {
-        Date d;
+    public String toString(Date o, String formatString, Locale locale) {
         if ( formatString==null ) formatString = "short";
-        if ( o instanceof Calendar ) d = ((Calendar)o).getTime();
-        else d = (Date)o;
         Integer styleI = formatToInt.get(formatString);
         DateFormat f;
         if ( styleI==null ) f = new SimpleDateFormat(formatString, locale);
@@ -73,6 +70,6 @@ public class DateRenderer implements AttributeRenderer {
             else if ( formatString.startsWith("time:") ) f = DateFormat.getTimeInstance(style, locale);
             else f = DateFormat.getDateTimeInstance(style, style, locale);
         }
-        return f.format(d);
+        return f.format(o);
     }
 }

--- a/src/org/stringtemplate/v4/Interpreter.java
+++ b/src/org/stringtemplate/v4/Interpreter.java
@@ -780,7 +780,7 @@ public class Interpreter {
 		String formatString = null;
 		if ( options!=null ) formatString = options[Option.FORMAT.ordinal()];
 		// ask the native group defining the surrounding template for the renderer
-		AttributeRenderer r = scope.st.impl.nativeGroup.getAttributeRenderer(o.getClass());
+		AttributeRenderer<? super Object> r = scope.st.impl.nativeGroup.getAttributeRenderer(o.getClass());
 		String v;
 		if ( r!=null ) v = r.toString(o, formatString, locale);
 		else v = o.toString();
@@ -793,7 +793,7 @@ public class Interpreter {
 		}
 		return n;
 	}
-
+	
 	protected int getExprStartChar(InstanceScope scope) {
 		Interval templateLocation = scope.st.impl.sourceMap[scope.ip];
 		if ( templateLocation!=null ) return templateLocation.a;
@@ -1196,7 +1196,7 @@ public class Interpreter {
 
 		try {
 			final ST self = scope.st;
-			ModelAdaptor adap = self.groupThatCreatedThisInstance.getModelAdaptor(o.getClass());
+			ModelAdaptor<? super Object> adap = self.groupThatCreatedThisInstance.getModelAdaptor(o.getClass());
 			return adap.getProperty(this, self, o, property, toString(out,scope,property));
 		}
 		catch (STNoSuchPropertyException e) {

--- a/src/org/stringtemplate/v4/ModelAdaptor.java
+++ b/src/org/stringtemplate/v4/ModelAdaptor.java
@@ -44,7 +44,7 @@ import java.util.Map;
  * Given {@code <a.foo>}, we look up {@code foo} via the adaptor if
  * {@code a instanceof M}.</p>
  */
-public interface ModelAdaptor {
+public interface ModelAdaptor<M> {
 	/**
 	 * Lookup property name in {@code o} and return its value.
 	 * <p>
@@ -53,6 +53,6 @@ public interface ModelAdaptor {
 	 * any key type. If we need to convert to {@code String}, then it's done by
 	 * {@code ST} and passed in here.</p>
 	 */
-	public Object getProperty(Interpreter interp, ST self, Object o, Object property, String propertyName)
+	public Object getProperty(Interpreter interp, ST self, M o, Object property, String propertyName)
 		throws STNoSuchPropertyException;
 }

--- a/src/org/stringtemplate/v4/NumberRenderer.java
+++ b/src/org/stringtemplate/v4/NumberRenderer.java
@@ -39,10 +39,9 @@ import java.util.Locale;
  *  For example, {@code %10d} emits a number as a decimal int padding to 10 char.
  *  This can even do {@code long} to {@code Date} conversions using the format string.</p>
  */
-public class NumberRenderer implements AttributeRenderer {
+public class NumberRenderer implements AttributeRenderer<Number> {
 	@Override
-    public String toString(Object o, String formatString, Locale locale) {
-        // o will be instanceof Number
+    public String toString(Number o, String formatString, Locale locale) {
         if ( formatString==null ) return o.toString();
         Formatter f = new Formatter(locale);
         f.format(formatString, o);

--- a/src/org/stringtemplate/v4/STGroup.java
+++ b/src/org/stringtemplate/v4/STGroup.java
@@ -97,7 +97,7 @@ public class STGroup {
 	 *  <p>
      *  This structure is synchronized.</p>
      */
-    protected Map<Class<?>, AttributeRenderer> renderers;
+    protected Map<Class<?>, AttributeRenderer<?>> renderers;
 
     /** A dictionary that allows people to register a model adaptor for
      *  a particular kind of object (subclass or implementation). Applies
@@ -108,9 +108,9 @@ public class STGroup {
 	 * <p>
 	 *  The last one you register gets priority; do least to most specific.</p>
 	 */
-	protected final Map<Class<?>, ModelAdaptor> adaptors;
+	protected final Map<Class<?>, ModelAdaptor<?>> adaptors;
 	{
-		TypeRegistry<ModelAdaptor> registry = new TypeRegistry<ModelAdaptor>();
+		TypeRegistry<ModelAdaptor<?>> registry = new TypeRegistry<ModelAdaptor<?>>();
 		registry.put(Object.class, new ObjectModelAdaptor());
 		registry.put(ST.class, new STModelAdaptor());
 		registry.put(Map.class, new MapModelAdaptor());
@@ -670,7 +670,7 @@ public class STGroup {
 	 * This must invalidate cache entries, so set your adaptors up before
 	 * calling {@link ST#render} for efficiency.</p>
 	 */
-	public void registerModelAdaptor(Class<?> attributeType, ModelAdaptor adaptor) {
+	public <M> void registerModelAdaptor(Class<M> attributeType, ModelAdaptor<? super M> adaptor) {
 		if ( attributeType.isPrimitive() ) {
 			throw new IllegalArgumentException("can't register ModelAdaptor for primitive type "+
 											   attributeType.getSimpleName());
@@ -679,8 +679,9 @@ public class STGroup {
 		adaptors.put(attributeType, adaptor);
 	}
 
-	public ModelAdaptor getModelAdaptor(Class<?> attributeType) {
-		return adaptors.get(attributeType);
+	@SuppressWarnings("unchecked")
+    public <M> ModelAdaptor<? super M> getModelAdaptor(Class<? extends M> attributeType) {
+		return (ModelAdaptor<? super M>) adaptors.get(attributeType);
 	}
 
     /** Register a renderer for all objects of a particular "kind" for all
@@ -688,18 +689,18 @@ public class STGroup {
 	 *  object in question is an instance of {@code attributeType}.  Recursively
 	 *  set renderer into all import groups.
      */
-    public void registerRenderer(Class<?> attributeType, AttributeRenderer r) {
+    public <T> void registerRenderer(Class<T> attributeType, AttributeRenderer<? super T> r) {
 		registerRenderer(attributeType, r, true);
 	}
 
-	public void registerRenderer(Class<?> attributeType, AttributeRenderer r, boolean recursive) {
+	public <T> void registerRenderer(Class<T> attributeType, AttributeRenderer<? super T> r, boolean recursive) {
 		if ( attributeType.isPrimitive() ) {
 			throw new IllegalArgumentException("can't register renderer for primitive type "+
 											   attributeType.getSimpleName());
 		}
 
 		if ( renderers == null ) {
-			renderers = Collections.synchronizedMap(new TypeRegistry<AttributeRenderer>());
+			renderers = Collections.synchronizedMap(new TypeRegistry<AttributeRenderer<?>>());
 		}
 
 		renderers.put(attributeType, r);
@@ -723,12 +724,13 @@ public class STGroup {
 	 *  have multiple renderers for {@code String}, say, then just make uber combined
 	 *  renderer with more specific format names.</p>
 	 */
-	public AttributeRenderer getAttributeRenderer(Class<?> attributeType) {
+	@SuppressWarnings("unchecked")
+    public <T> AttributeRenderer<? super T> getAttributeRenderer(Class<? extends T> attributeType) {
 		if ( renderers==null ) {
 			return null;
 		}
 
-		return renderers.get(attributeType);
+		return (AttributeRenderer<? super T>) renderers.get(attributeType);
 	}
 
 	public ST createStringTemplate(CompiledST impl) {

--- a/src/org/stringtemplate/v4/StringRenderer.java
+++ b/src/org/stringtemplate/v4/StringRenderer.java
@@ -40,28 +40,27 @@ import java.util.Locale;
  *  <li>{@code xml-encode}:</li>
  * </ul>
  */
-public class StringRenderer implements AttributeRenderer {
+public class StringRenderer implements AttributeRenderer<String> {
     // trim(s) and strlen(s) built-in funcs; these are format options
     @Override
-    public String toString(Object o, String formatString, Locale locale) {
-        String s = (String)o;
-        if ( formatString==null ) return s;
-        if ( formatString.equals("upper") ) return s.toUpperCase(locale);
-        if ( formatString.equals("lower") ) return s.toLowerCase(locale);
+    public String toString(String o, String formatString, Locale locale) {
+        if ( formatString==null ) return o;
+        if ( formatString.equals("upper") ) return o.toUpperCase(locale);
+        if ( formatString.equals("lower") ) return o.toLowerCase(locale);
         if ( formatString.equals("cap") ) {
-            return (s.length() > 0) ? Character.toUpperCase(s.charAt(0))+s.substring(1) : s;
+            return (o.length() > 0) ? Character.toUpperCase(o.charAt(0))+o.substring(1) : o;
         }
         if ( formatString.equals("url-encode") ) {
 			try {
-				return URLEncoder.encode(s, "UTF-8");
+				return URLEncoder.encode(o, "UTF-8");
 			} catch (UnsupportedEncodingException ex) {
 				// UTF-8 is standard, should always be available
 			}
         }
         if ( formatString.equals("xml-encode") ) {
-            return escapeHTML(s);
+            return escapeHTML(o);
         }
-        return String.format(locale, formatString, s);
+        return String.format(locale, formatString, o);
     }
 
     public static String escapeHTML(String s) {

--- a/src/org/stringtemplate/v4/misc/AggregateModelAdaptor.java
+++ b/src/org/stringtemplate/v4/misc/AggregateModelAdaptor.java
@@ -28,18 +28,21 @@
 
 package org.stringtemplate.v4.misc;
 
-import org.stringtemplate.v4.Interpreter;
-import org.stringtemplate.v4.ST;
-
 import java.util.Map;
 
+import org.stringtemplate.v4.Interpreter;
+import org.stringtemplate.v4.ModelAdaptor;
+import org.stringtemplate.v4.ST;
+
 /** Deal with structs created via {@link ST#addAggr}{@code ("structname.{prop1, prop2}", ...);}. */
-public class AggregateModelAdaptor extends MapModelAdaptor {
+public class AggregateModelAdaptor implements ModelAdaptor<Aggregate> {
+    private final MapModelAdaptor delegate = new MapModelAdaptor();
+    
 	@Override
-	public Object getProperty(Interpreter interp, ST self, Object o, Object property, String propertyName)
+	public Object getProperty(Interpreter interp, ST self, Aggregate o, Object property, String propertyName)
 		throws STNoSuchPropertyException
 	{
-		Map<?, ?> map = ((Aggregate)o).properties;
-		return super.getProperty(interp, self, map, property, propertyName);
+		Map<?, ?> map = o.properties;
+		return delegate.getProperty(interp, self, map, property, propertyName);
 	}
 }

--- a/src/org/stringtemplate/v4/misc/MapModelAdaptor.java
+++ b/src/org/stringtemplate/v4/misc/MapModelAdaptor.java
@@ -34,21 +34,20 @@ import org.stringtemplate.v4.STGroup;
 
 import java.util.Map;
 
-public class MapModelAdaptor implements ModelAdaptor {
+public class MapModelAdaptor implements ModelAdaptor<Map<?,?>> {
 	@Override
-	public Object getProperty(Interpreter interp, ST self, Object o, Object property, String propertyName)
+	public Object getProperty(Interpreter interp, ST self, Map<?,?> o, Object property, String propertyName)
 		throws STNoSuchPropertyException
 	{
 		Object value;
-		Map<?, ?> map = (Map<?, ?>)o;
-		if ( property==null ) value = map.get(STGroup.DEFAULT_KEY);
-		else if ( property.equals("keys") ) value = map.keySet();
-		else if ( property.equals("values") ) value = map.values();
-		else if ( map.containsKey(property) ) value = map.get(property);
-		else if ( map.containsKey(propertyName) ) { // if can't find the key, try toString version
-			value = map.get(propertyName);
+		if ( property==null ) value = o.get(STGroup.DEFAULT_KEY);
+		else if ( property.equals("keys") ) value = o.keySet();
+		else if ( property.equals("values") ) value = o.values();
+		else if ( o.containsKey(property) ) value = o.get(property);
+		else if ( o.containsKey(propertyName) ) { // if can't find the key, try toString version
+			value = o.get(propertyName);
 		}
-		else value = map.get(STGroup.DEFAULT_KEY); // not found, use default
+		else value = o.get(STGroup.DEFAULT_KEY); // not found, use default
 		if ( value == STGroup.DICT_KEY ) {
 			value = property;
 		}

--- a/src/org/stringtemplate/v4/misc/ObjectModelAdaptor.java
+++ b/src/org/stringtemplate/v4/misc/ObjectModelAdaptor.java
@@ -39,7 +39,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-public class ObjectModelAdaptor implements ModelAdaptor {
+public class ObjectModelAdaptor implements ModelAdaptor<Object> {
 	protected static final Member INVALID_MEMBER;
 	static {
 		Member invalidMember;

--- a/src/org/stringtemplate/v4/misc/STModelAdaptor.java
+++ b/src/org/stringtemplate/v4/misc/STModelAdaptor.java
@@ -31,12 +31,11 @@ import org.stringtemplate.v4.Interpreter;
 import org.stringtemplate.v4.ModelAdaptor;
 import org.stringtemplate.v4.ST;
 
-public class STModelAdaptor implements ModelAdaptor {
+public class STModelAdaptor implements ModelAdaptor<ST> {
 	@Override
-	public Object getProperty(Interpreter interp, ST self, Object o, Object property, String propertyName)
+	public Object getProperty(Interpreter interp, ST self, ST o, Object property, String propertyName)
 		throws STNoSuchPropertyException
 	{
-		ST st = (ST)o;
-		return st.getAttribute(propertyName);
+		return o.getAttribute(propertyName);
 	}
 }

--- a/test/org/stringtemplate/v4/test/TestModelAdaptors.java
+++ b/test/org/stringtemplate/v4/test/TestModelAdaptors.java
@@ -9,20 +9,20 @@ import org.stringtemplate.v4.misc.STRuntimeMessage;
 import static org.junit.Assert.assertEquals;
 
 public class TestModelAdaptors extends BaseTest {
-	static class UserAdaptor implements ModelAdaptor {
+	static class UserAdaptor implements ModelAdaptor<User> {
 		@Override
-		public Object getProperty(Interpreter interp, ST self, Object o, Object property, String propertyName)
+		public Object getProperty(Interpreter interp, ST self, User o, Object property, String propertyName)
 			throws STNoSuchPropertyException
 		{
-			if ( propertyName.equals("id") ) return ((User)o).id;
-			if ( propertyName.equals("name") ) return ((User)o).getName();
+			if ( propertyName.equals("id") ) return o.id;
+			if ( propertyName.equals("name") ) return o.getName();
 			throw new STNoSuchPropertyException(null, o, "User."+propertyName);
 		}
 	}
 
-	static class UserAdaptorConst implements ModelAdaptor {
+	static class UserAdaptorConst implements ModelAdaptor<User> {
 		@Override
-		public Object getProperty(Interpreter interp, ST self, Object o, Object property, String propertyName)
+		public Object getProperty(Interpreter interp, ST self, User o, Object property, String propertyName)
 			throws STNoSuchPropertyException
 		{
 			if ( propertyName.equals("id") ) return "const id value";

--- a/test/org/stringtemplate/v4/test/TestRenderers.java
+++ b/test/org/stringtemplate/v4/test/TestRenderers.java
@@ -56,7 +56,7 @@ public class TestRenderers extends BaseTest {
 				"dateThing(created) ::= \"datetime: <created>\"\n";
 		writeFile(tmpdir, "t.stg", templates);
 		STGroup group = new STGroupFile(tmpdir+"/t.stg");
-		group.registerRenderer(GregorianCalendar.class, new DateRenderer());
+		group.registerRenderer(GregorianCalendar.class, new CalendarRenderer());
 		ST st = group.getInstanceOf("dateThing");
 		st.add("created", new GregorianCalendar(2005, 07-1, 05));
 		String expecting = "datetime: 7/5/05 12:00 AM";
@@ -69,7 +69,7 @@ public class TestRenderers extends BaseTest {
                 "dateThing(created) ::= << date: <created; format=\"yyyy.MM.dd\"> >>\n";
         writeFile(tmpdir, "t.stg", templates);
         STGroup group = new STGroupFile(tmpdir+"/t.stg");
-        group.registerRenderer(GregorianCalendar.class, new DateRenderer());
+        group.registerRenderer(GregorianCalendar.class, new CalendarRenderer());
         ST st = group.getInstanceOf("dateThing");
         st.add("created", new GregorianCalendar(2005, 07-1, 05));
         String expecting = " date: 2005.07.05 ";
@@ -82,7 +82,7 @@ public class TestRenderers extends BaseTest {
                 "dateThing(created) ::= << datetime: <created; format=\"short\"> >>\n";
         writeFile(tmpdir, "t.stg", templates);
         STGroup group = new STGroupFile(tmpdir+"/t.stg");
-        group.registerRenderer(GregorianCalendar.class, new DateRenderer());
+        group.registerRenderer(GregorianCalendar.class, new CalendarRenderer());
         ST st = group.getInstanceOf("dateThing");
         st.add("created", new GregorianCalendar(2005, 07-1, 05));
         String expecting = " datetime: 7/5/05 12:00 AM ";
@@ -95,7 +95,7 @@ public class TestRenderers extends BaseTest {
                 "dateThing(created) ::= << datetime: <created; format=\"full\"> >>\n";
         writeFile(tmpdir, "t.stg", templates);
         STGroup group = new STGroupFile(tmpdir+"/t.stg");
-        group.registerRenderer(GregorianCalendar.class, new DateRenderer());
+        group.registerRenderer(GregorianCalendar.class, new CalendarRenderer());
         ST st = group.getInstanceOf("dateThing");
         TimeZone origTimeZone = TimeZone.getDefault();
         try {
@@ -117,7 +117,7 @@ public class TestRenderers extends BaseTest {
 
         writeFile(tmpdir, "t.stg", templates);
         STGroup group = new STGroupFile(tmpdir+"/t.stg");
-        group.registerRenderer(GregorianCalendar.class, new DateRenderer());
+        group.registerRenderer(GregorianCalendar.class, new CalendarRenderer());
         ST st = group.getInstanceOf("dateThing");
         st.add("created", new GregorianCalendar(2005, 07-1, 05));
         String expecting = " date: Jul 5, 2005 ";
@@ -131,7 +131,7 @@ public class TestRenderers extends BaseTest {
 
         writeFile(tmpdir, "t.stg", templates);
         STGroup group = new STGroupFile(tmpdir+"/t.stg");
-        group.registerRenderer(GregorianCalendar.class, new DateRenderer());
+        group.registerRenderer(GregorianCalendar.class, new CalendarRenderer());
         ST st = group.getInstanceOf("dateThing");
         st.add("created", new GregorianCalendar(2005, 07-1, 05));
         String expecting = " time: 12:00:00 AM ";
@@ -351,7 +351,7 @@ public class TestRenderers extends BaseTest {
 	@Test public void testDateRendererWithLocale() {
 		String input = "<date; format=\"dd 'de' MMMMM 'de' yyyy\">";
 		STGroup group = new STGroup();
-		group.registerRenderer(Calendar.class, new DateRenderer());
+		group.registerRenderer(Calendar.class, new CalendarRenderer());
 		ST st = new ST(group, input);
 
 		Calendar cal = Calendar.getInstance();


### PR DESCRIPTION
Improved the type safety of AttributeRenderer and ModelAdaptor by converting them to generic interfaces.

Another goal behind this is to help dependency injection for `AttributeRenderer`s and `ModelAdaptor`s. If using a framework such as Guice, you can bind each `AttributeRenderer<SomeType>` to an implementation. If the interface is not generic you have to create a separate [binding annotation](https://code.google.com/p/google-guice/wiki/BindingAnnotations) for each `AttributeRenderer`, which requires a lot of boilerplate.