### PR TITLE
Default start/stop delimiters in STGroupFile overloaded constructor

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -50,3 +50,4 @@ CONTRIBUTORS:
 YYYY/MM/DD, github id, Full name, email
 2012/07/12, parrt, Terence Parr, parrt@antlr.org
 2012/08/13, pgelinas, Pascal Gélinas, pascal.gelinas@polymtl.ca
+2014/06/24, pietrom, Pietro Martinelli, amicofragile@gmail.com

--- a/src/org/stringtemplate/v4/STGroup.java
+++ b/src/org/stringtemplate/v4/STGroup.java
@@ -44,6 +44,8 @@ import java.util.*;
  *  Name inside must match filename (minus suffix).
  */
 public class STGroup {
+	protected static final char DEFAULT_START_DELIMITER = '<';
+	protected static final char DEFAULT_STOP_DELIMITER = '>';
 	public static final String GROUP_FILE_EXTENSION;
 	public static final String TEMPLATE_FILE_EXTENSION;
 	static {
@@ -65,8 +67,8 @@ public class STGroup {
 
     protected final List<STGroup> importsToClearOnUnload = Collections.synchronizedList(new ArrayList<STGroup>());
 
-    public char delimiterStartChar = '<'; // Use <expr> by default
-    public char delimiterStopChar = '>';
+    public char delimiterStartChar = DEFAULT_START_DELIMITER; // Use <expr> by default
+    public char delimiterStopChar = DEFAULT_STOP_DELIMITER;
 
     /** Maps template name to {@link CompiledST} object. This map is synchronized. */
     protected Map<String, CompiledST> templates =

--- a/src/org/stringtemplate/v4/STGroupFile.java
+++ b/src/org/stringtemplate/v4/STGroupFile.java
@@ -39,13 +39,15 @@ import java.net.*;
  *  or an import.
  */
 public class STGroupFile extends STGroup {
+	private static final char DEFAULT_START_DELIMITER = '<';
+	private static final char DEFAULT_STOP_DELIMITER = '>';
     public String fileName;
     public URL url;
 
     protected boolean alreadyLoaded = false;
 
     /** Load a file relative to current directory or from root or via CLASSPATH. */
-	public STGroupFile(String fileName) { this(fileName, '<', '>'); }
+	public STGroupFile(String fileName) { this(fileName, DEFAULT_START_DELIMITER, DEFAULT_STOP_DELIMITER); }
 
 	public STGroupFile(String fileName, char delimiterStartChar, char delimiterStopChar) {
 		super(delimiterStartChar, delimiterStopChar);
@@ -75,7 +77,7 @@ public class STGroupFile extends STGroup {
 	}
 
 	public STGroupFile(String fullyQualifiedFileName, String encoding) {
-        this(fullyQualifiedFileName, encoding, '<', '>');
+        this(fullyQualifiedFileName, encoding, DEFAULT_START_DELIMITER, DEFAULT_STOP_DELIMITER);
     }
 
     public STGroupFile(String fullyQualifiedFileName, String encoding,
@@ -86,7 +88,7 @@ public class STGroupFile extends STGroup {
     }
 
     public STGroupFile(URL url, String encoding) {
-    	this(url, encoding, '<', '>');
+    	this(url, encoding, DEFAULT_START_DELIMITER, DEFAULT_STOP_DELIMITER);
     }
     
 	public STGroupFile(URL url, String encoding,

--- a/src/org/stringtemplate/v4/STGroupFile.java
+++ b/src/org/stringtemplate/v4/STGroupFile.java
@@ -85,6 +85,10 @@ public class STGroupFile extends STGroup {
         this.encoding = encoding;
     }
 
+    public STGroupFile(URL url, String encoding) {
+    	this(url, encoding, '<', '>');
+    }
+    
 	public STGroupFile(URL url, String encoding,
 					   char delimiterStartChar, char delimiterStopChar)
 	{

--- a/src/org/stringtemplate/v4/STGroupFile.java
+++ b/src/org/stringtemplate/v4/STGroupFile.java
@@ -39,8 +39,6 @@ import java.net.*;
  *  or an import.
  */
 public class STGroupFile extends STGroup {
-	private static final char DEFAULT_START_DELIMITER = '<';
-	private static final char DEFAULT_STOP_DELIMITER = '>';
     public String fileName;
     public URL url;
 

--- a/test/org/stringtemplate/v4/test/BaseTest.java
+++ b/test/org/stringtemplate/v4/test/BaseTest.java
@@ -341,7 +341,7 @@ public abstract class BaseTest {
 	}
 
     public static String getRandomDir() {
-        String randomDir = tmpdir+"dir"+String.valueOf((int)(Math.random()*100000));
+        String randomDir = tmpdir+"/dir"+String.valueOf((int)(Math.random()*100000));
         File f = new File(randomDir);
         f.mkdirs();
         return randomDir;

--- a/test/org/stringtemplate/v4/test/TestImports.java
+++ b/test/org/stringtemplate/v4/test/TestImports.java
@@ -305,6 +305,43 @@ public class TestImports extends BaseTest {
 		String expected = "subdir b";
 		assertEquals(expected, result);
 	}
+	@Test public void testImportRelativeDirInJarViaCLASSPATHWithDefaultDelimiters() throws Exception {
+		/*
+		org/foo/templates
+			g.stg has a() that imports subdir with relative path
+			subdir
+				a.st
+				b.st
+				c.st
+		 */
+		String root = getRandomDir();
+		System.out.println(root);
+		String dir = root+"/org/foo/templates";
+		String gstr =
+				"import \"subdir\"\n" + // finds subdir in dir
+						"a() ::= <<dir1 a>>\n";
+		writeFile(dir, "g.stg", gstr);
+		
+		String a = "a() ::= <<subdir a>>\n";
+		String b = "b() ::= <<subdir b>>\n";
+		String c = "c() ::= <<subdir b>>\n";
+		writeFile(dir, "subdir/a.st", a);
+		writeFile(dir, "subdir/b.st", b);
+		writeFile(dir, "subdir/c.st", c);
+		
+		jar("test.jar", new String[] {"org"}, root);
+		deleteFile(root + "/org");
+		
+		File path = new File(root + File.separatorChar + "test.jar");
+		assertTrue(path.isFile());
+		URLClassLoader loader = new URLClassLoader(new URL[] { path.toURI().toURL() });
+		STGroup group = new STGroupFile(loader.getResource("org/foo/templates/g.stg"), "UTF-8");
+		ST st = group.getInstanceOf("b");
+		String result = st.render();
+		
+		String expected = "subdir b";
+		assertEquals(expected, result);
+	}
 
 	@Test public void testEmptyGroupImportGroupFileSameDir() throws Exception {
 		/*

--- a/test/org/stringtemplate/v4/test/TestImports.java
+++ b/test/org/stringtemplate/v4/test/TestImports.java
@@ -269,33 +269,7 @@ public class TestImports extends BaseTest {
 	}
 
 	@Test public void testImportRelativeDirInJarViaCLASSPATH() throws Exception {
-		/*
-		org/foo/templates
-			g.stg has a() that imports subdir with relative path
-			subdir
-				a.st
-				b.st
-				c.st
-		 */
-		String root = getRandomDir();
-		System.out.println(root);
-		String dir = root+"/org/foo/templates";
-		String gstr =
-				"import \"subdir\"\n" + // finds subdir in dir
-						"a() ::= <<dir1 a>>\n";
-		writeFile(dir, "g.stg", gstr);
-
-		String a = "a() ::= <<subdir a>>\n";
-		String b = "b() ::= <<subdir b>>\n";
-		String c = "c() ::= <<subdir b>>\n";
-		writeFile(dir, "subdir/a.st", a);
-		writeFile(dir, "subdir/b.st", b);
-		writeFile(dir, "subdir/c.st", c);
-
-		jar("test.jar", new String[] {"org"}, root);
-		deleteFile(root + "/org");
-
-		File path = new File(root + File.separatorChar + "test.jar");
+		File path = prepareTemplateDirsAndFilesForImportRelativeDirInJarViaCLASSPATHTests();
 		assertTrue(path.isFile());
 		URLClassLoader loader = new URLClassLoader(new URL[] { path.toURI().toURL() });
 		STGroup group = new STGroupFile(loader.getResource("org/foo/templates/g.stg"), "UTF-8", '<', '>');
@@ -305,7 +279,20 @@ public class TestImports extends BaseTest {
 		String expected = "subdir b";
 		assertEquals(expected, result);
 	}
+	
 	@Test public void testImportRelativeDirInJarViaCLASSPATHWithDefaultDelimiters() throws Exception {
+		File path = prepareTemplateDirsAndFilesForImportRelativeDirInJarViaCLASSPATHTests();
+		assertTrue(path.isFile());
+		URLClassLoader loader = new URLClassLoader(new URL[] { path.toURI().toURL() });
+		STGroup group = new STGroupFile(loader.getResource("org/foo/templates/g.stg"), "UTF-8");
+		ST st = group.getInstanceOf("b");
+		String result = st.render();
+		
+		String expected = "subdir b";
+		assertEquals(expected, result);
+	}
+	
+	private File prepareTemplateDirsAndFilesForImportRelativeDirInJarViaCLASSPATHTests() throws Exception {
 		/*
 		org/foo/templates
 			g.stg has a() that imports subdir with relative path
@@ -333,14 +320,7 @@ public class TestImports extends BaseTest {
 		deleteFile(root + "/org");
 		
 		File path = new File(root + File.separatorChar + "test.jar");
-		assertTrue(path.isFile());
-		URLClassLoader loader = new URLClassLoader(new URL[] { path.toURI().toURL() });
-		STGroup group = new STGroupFile(loader.getResource("org/foo/templates/g.stg"), "UTF-8");
-		ST st = group.getInstanceOf("b");
-		String result = st.render();
-		
-		String expected = "subdir b";
-		assertEquals(expected, result);
+		return path;
 	}
 
 	@Test public void testEmptyGroupImportGroupFileSameDir() throws Exception {


### PR DESCRIPTION
I've added an overloaded constructor to class STGroupFile, in order to allow STGroupDir initialization by URL, without the need to explicitly specify start and stop delimiters.

Reopened after I've added my signoff to contributors' list.