### PR TITLE
Test execution on Linux (*nix)

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -50,3 +50,4 @@ CONTRIBUTORS:
 YYYY/MM/DD, github id, Full name, email
 2012/07/12, parrt, Terence Parr, parrt@antlr.org
 2012/08/13, pgelinas, Pascal Gélinas, pascal.gelinas@polymtl.ca
+2014/09/25, mpdeimos, Martin Pöhlmann, <githubid>@outlook.com

--- a/test/org/stringtemplate/v4/test/BaseTest.java
+++ b/test/org/stringtemplate/v4/test/BaseTest.java
@@ -49,8 +49,8 @@ import static org.junit.Assert.assertTrue;
 
 public abstract class BaseTest {
 	public static final String pathSep = System.getProperty("path.separator");
-    public static final String tmpdir = System.getProperty("java.io.tmpdir");
-    public static int tmpdirSuffix = 1;
+    public static final String tmpdir = System.getProperty("java.io.tmpdir") + File.separator + "st-tmp-dir";
+    private static int tmpdirSuffix = 1;
 	public static final boolean interactive = Boolean.parseBoolean(System.getProperty("test.interactive"));
     public static final String newline = Misc.newline;
 
@@ -342,8 +342,7 @@ public abstract class BaseTest {
 	}
 
     public static String getRandomDir() {
-        String randomDir = tmpdir + File.separator + "st-tmp-dir"
-                + File.separator + (tmpdirSuffix++);
+        String randomDir = tmpdir + File.separator + (tmpdirSuffix++);
         File f = new File(randomDir);
         f.mkdirs();
         return randomDir;

--- a/test/org/stringtemplate/v4/test/BaseTest.java
+++ b/test/org/stringtemplate/v4/test/BaseTest.java
@@ -50,7 +50,6 @@ import static org.junit.Assert.assertTrue;
 public abstract class BaseTest {
 	public static final String pathSep = System.getProperty("path.separator");
     public static final String tmpdir = System.getProperty("java.io.tmpdir") + File.separator + "st-tmp-dir";
-    private static int tmpdirSuffix = 1;
 	public static final boolean interactive = Boolean.parseBoolean(System.getProperty("test.interactive"));
     public static final String newline = Misc.newline;
 
@@ -342,7 +341,7 @@ public abstract class BaseTest {
 	}
 
     public static String getRandomDir() {
-        String randomDir = tmpdir + File.separator + (tmpdirSuffix++);
+        String randomDir = tmpdir + File.separator + System.nanoTime();
         File f = new File(randomDir);
         f.mkdirs();
         return randomDir;

--- a/test/org/stringtemplate/v4/test/BaseTest.java
+++ b/test/org/stringtemplate/v4/test/BaseTest.java
@@ -50,6 +50,7 @@ import static org.junit.Assert.assertTrue;
 public abstract class BaseTest {
 	public static final String pathSep = System.getProperty("path.separator");
     public static final String tmpdir = System.getProperty("java.io.tmpdir");
+    public static int tmpdirSuffix = 1;
 	public static final boolean interactive = Boolean.parseBoolean(System.getProperty("test.interactive"));
     public static final String newline = Misc.newline;
 
@@ -341,7 +342,8 @@ public abstract class BaseTest {
 	}
 
     public static String getRandomDir() {
-        String randomDir = tmpdir+"dir"+String.valueOf((int)(Math.random()*100000));
+        String randomDir = tmpdir + File.separator + "st-tmp-dir"
+                + File.separator + (tmpdirSuffix++);
         File f = new File(randomDir);
         f.mkdirs();
         return randomDir;


### PR DESCRIPTION
Currently test files are created using `tmpdir + "dir" + randomValue`.

On Linux (and most other *nix systems like Mac OS) `tmpdir` mostly yields `/tmp` (note no trailing slash) and above concatenation results in e.g. `/tmpdir0123456`. However, regularly you do not have access rights to write directly in the filesystem root and thus several of the tests fail. Writing in `/tmp/dir0123456` would work, tho.

The following pull request contains this fix with two additions:
* Changing from random folder numbers to a counter for the "number part" of the test directory. Doing so will prevent the tests from flickering.
* I've added another directory layer, so all test files are in one directory (makes deleting easier)

This results in e.g. `/tmp/st-tmp-dir/56`on my machine.

Something else:
In my test environments I usually clear such temp directories in a create method, so I am sure no files from previous test runs are present. Should we add this here as well?