### PR TITLE
Fixed tmpdir variable, for pull request #103

### DIFF
--- a/test/org/stringtemplate/v4/test/BaseTest.java
+++ b/test/org/stringtemplate/v4/test/BaseTest.java
@@ -49,7 +49,7 @@ import static org.junit.Assert.assertTrue;
 
 public abstract class BaseTest {
 	public static final String pathSep = System.getProperty("path.separator");
-    public static final String tmpdir = System.getProperty("java.io.tmpdir");
+    public static final String tmpdir = System.getProperty("java.io.tmpdir") + File.separator;
 	public static final boolean interactive = Boolean.parseBoolean(System.getProperty("test.interactive"));
     public static final String newline = Misc.newline;
 


### PR DESCRIPTION
Simple change to ensure tmpdir ends up with a slash (for Unix systems), or backslash (for Windows), so the tests generating temporary files do not fail due to "cannot write file" errors.