### PR TITLE
Unique test folders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -297,6 +297,9 @@ There are currently about 600 StringTemplate source downloads a month.
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.17</version>
                 <configuration>
+                    <systemProperties>
+                        <java.io.tmpdir>${project.build.directory}/test-output/</java.io.tmpdir>
+                    </systemProperties>
                     <additionalClasspathElements>
                         <additionalClasspathElement>${basedir}/src</additionalClasspathElement>
                     </additionalClasspathElements>

--- a/test/org/stringtemplate/v4/test/BaseTest.java
+++ b/test/org/stringtemplate/v4/test/BaseTest.java
@@ -346,7 +346,9 @@ public abstract class BaseTest {
 	}
 
 	public String getRandomDir() {
-		return tmpdir;
+		File randomDir = new File(tmpdir, "dir" + String.valueOf((int)(Math.random() * 100000)));
+		randomDir.mkdirs();
+		return randomDir.getAbsolutePath();
 	}
 
 	/**

--- a/test/org/stringtemplate/v4/test/BaseTest.java
+++ b/test/org/stringtemplate/v4/test/BaseTest.java
@@ -49,9 +49,10 @@ import static org.junit.Assert.assertTrue;
 
 public abstract class BaseTest {
 	public static final String pathSep = System.getProperty("path.separator");
-    public static final String tmpdir = System.getProperty("java.io.tmpdir");
 	public static final boolean interactive = Boolean.parseBoolean(System.getProperty("test.interactive"));
     public static final String newline = Misc.newline;
+
+	public String tmpdir = null;
 
 	/**
 	 * When runnning from Maven, the junit tests are run via the surefire plugin. It sets the
@@ -105,6 +106,10 @@ public abstract class BaseTest {
     public void setUp() {
         STGroup.defaultGroup = new STGroup();
         Compiler.subtemplateCount = 0;
+
+        String baseTestDirectory = System.getProperty("java.io.tmpdir");
+        String testDirectory = getClass().getSimpleName() + "-" + System.currentTimeMillis();
+        tmpdir = new File(baseTestDirectory, testDirectory).getAbsolutePath();
     }
 
     /**
@@ -340,12 +345,9 @@ public abstract class BaseTest {
         }
 	}
 
-    public static String getRandomDir() {
-        String randomDir = tmpdir+"dir"+String.valueOf((int)(Math.random()*100000));
-        File f = new File(randomDir);
-        f.mkdirs();
-        return randomDir;
-    }
+	public String getRandomDir() {
+		return tmpdir;
+	}
 
 	/**
 	 * Removes the specified file or directory, and all subdirectories.

--- a/test/org/stringtemplate/v4/test/TestCompiler.java
+++ b/test/org/stringtemplate/v4/test/TestCompiler.java
@@ -65,9 +65,6 @@ import java.util.Arrays;
 import static org.junit.Assert.assertEquals;
 
 public class TestCompiler extends BaseTest {
-    @Before
-	@Override
-    public void setUp() { org.stringtemplate.v4.compiler.Compiler.subtemplateCount = 0; }
 
     @Test public void testAttr() throws Exception {
         String template = "hi <name>";

--- a/test/org/stringtemplate/v4/test/TestRenderers.java
+++ b/test/org/stringtemplate/v4/test/TestRenderers.java
@@ -42,6 +42,7 @@ public class TestRenderers extends BaseTest {
 	@Before
 	@Override
 	public void setUp() {
+		super.setUp();
 		origLocale = Locale.getDefault();
 		Locale.setDefault(Locale.US);
 	}


### PR DESCRIPTION
This pull request addresses the trailing separator issue described in #103. In addition, it makes the following changes to the test output folder:

1. It generates a unique `tmpdir` folder for each test.
2. When running the tests using Maven, it places the temporary folder within the `target` folder, which means the temporary directories are removed when you run `mvn clean`.

This pull request supersedes #104 and #91.