### PR TITLE
fix issue 114

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -50,3 +50,4 @@ CONTRIBUTORS:
 YYYY/MM/DD, github id, Full name, email
 2012/07/12, parrt, Terence Parr, parrt@antlr.org
 2012/08/13, pgelinas, Pascal Gélinas, pascal.gelinas@polymtl.ca
+2015/05/28, jsnyders, John Snyders, jjsnyders at rcn.com

--- a/src/org/stringtemplate/v4/STGroup.java
+++ b/src/org/stringtemplate/v4/STGroup.java
@@ -195,7 +195,7 @@ public class STGroup {
 	/** Create singleton template for use with dictionary values. */
 	public ST createSingleton(Token templateToken) {
 		String template;
-		if ( templateToken.getType()==GroupParser.BIGSTRING ) {
+		if ( templateToken.getType()==GroupParser.BIGSTRING || templateToken.getType()==GroupParser.BIGSTRING_NO_NL ) {
 			template = Misc.strip(templateToken.getText(),2);
 		}
 		else {

--- a/test/org/stringtemplate/v4/test/TestDictionaries.java
+++ b/test/org/stringtemplate/v4/test/TestDictionaries.java
@@ -492,4 +492,29 @@ public class TestDictionaries extends BaseTest {
 		assertEquals(expected, result);
 	}
 
+	/**
+	 * This is a regression test for antlr/stringtemplate4#114. 
+	 * "dictionary value using <% %> is broken"
+	 * Before the fix the following test would return %hi%
+	 * https://github.com/antlr/stringtemplate4/issues/114
+	 */
+	@Test
+	public void testDictionaryBehaviorNoNewlineTemplate() throws Exception {
+		String templates =
+			"d ::= [\n" +
+			"	\"x\" : <%hi%>\n" +
+			"]\n" +
+			"\n" +
+			"t() ::= <<\n" +
+			"<d.x>\n" +
+			">>\n";
+
+		writeFile(tmpdir, "t.stg", templates);
+		STGroup group = new STGroupFile(tmpdir + File.separatorChar + "t.stg");
+		ST st = group.getInstanceOf("t");
+		String expected = "hi";
+		String result = st.render();
+		assertEquals(expected, result);
+	}
+
 }


### PR DESCRIPTION
I believe this is one way to fix the issue 114. When a <% %> template was used as a dictionary value the %'s were not being stripped. 
I tested the change with this group template
```
delimiters "$","$"
d1 ::= [
  "p": <%hi%>
]
main() ::= <<$d1.p$>>
```
and the problem was fixed (expected result `hi` was returned).

Fixes #114