### PR TITLE
this.locals should be all EMPTY_ATTR instead of all null when cloned

### DIFF
--- a/src/org/stringtemplate/v4/ST.java
+++ b/src/org/stringtemplate/v4/ST.java
@@ -189,7 +189,11 @@ public class ST {
 			System.arraycopy(proto.locals, 0, this.locals, 0, proto.locals.length);
 		}
 		else if (impl.formalArguments != null && !impl.formalArguments.isEmpty()) {
-			this.locals = new Object[impl.formalArguments.size()];
+			int formalArgumentCount = impl.formalArguments.size();
+			this.locals = new Object[formalArgumentCount];
+			for (int i = 0; i < formalArgumentCount; i++) {
+				this.locals[i] = EMPTY_ATTR;
+			}
 		}
 		this.groupThatCreatedThisInstance = proto.groupThatCreatedThisInstance;
 	}


### PR DESCRIPTION
Consider the following code:

```
if (protoST == null) {
    protoST = new ST("<arg.x>");
}
ST st = new ST(protoST);
Map map = new HashMap();
map.put("x", 3);
st.add("arg", map);
st.render();
```

First time it's called, since inst.formatArguments == null, everything goes fine; `st.render()` returns "3".

On the second call, since st.add also created impl.formatArguments[0] during first call, now when clone constructor sets st.locals to new Object[1](containing a null), and since impl.formatArguments exists, `new FormalArgument(name)` branch won't be called, and thus `locals[arg.index] = EMPTY_ATTR` won't be called either. What happens is `curvalue==EMPTY_ATTR` fails and thus a ST.AttributeList is created containing a null and the wanted value, and thus arg.x isn't there and all goes to hell in the end.

Alternative solution would be to check `if ( curvalue == null || curvalue == EMPTY_ATTR )` but then you could as well do away with EMPTY_ATTR, so I figured maybe that's what you would like to have signifying an argument that hasn't yet got a value.
