### PR TITLE
[squid:S1155] Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/src/org/stringtemplate/v4/Interpreter.java
+++ b/src/org/stringtemplate/v4/Interpreter.java
@@ -878,7 +878,7 @@ public class Interpreter {
 	 */
 	// todo: i, i0 not set unless mentioned? map:{k,v | ..}?
 	protected ST.AttributeList zip_map(InstanceScope scope, List<Object> exprs, ST prototype) {
-		if ( exprs==null || prototype==null || exprs.size()==0 ) {
+		if ( exprs==null || prototype==null || exprs.isEmpty()) {
 			return null; // do not apply if missing templates or empty values
 		}
 		// make everything iterable
@@ -1187,8 +1187,8 @@ public class Interpreter {
 	protected boolean testAttributeTrue(Object a) {
 		if ( a==null ) return false;
 		if ( a instanceof Boolean ) return (Boolean)a;
-		if ( a instanceof Collection ) return ((Collection<?>)a).size()>0;
-		if ( a instanceof Map ) return ((Map<?, ?>)a).size()>0;
+		if ( a instanceof Collection ) return !((Collection<?>) a).isEmpty();
+		if ( a instanceof Map ) return !((Map<?, ?>) a).isEmpty();
 		if ( a instanceof Iterable ) {
 			return ((Iterable<?>)a).iterator().hasNext();
 		}

--- a/src/org/stringtemplate/v4/STGroup.java
+++ b/src/org/stringtemplate/v4/STGroup.java
@@ -294,7 +294,7 @@ public class STGroup {
     public void load() { }
 
     protected CompiledST lookupImportedTemplate(String name) {
-        if ( imports.size()==0 ) return null;
+        if (imports.isEmpty()) return null;
         for (STGroup g : imports) {
 			if ( verbose ) System.out.println("checking "+g.getName()+" for imported "+name);
             CompiledST code = g.lookupTemplate(name);
@@ -813,7 +813,7 @@ public class STGroup {
 
     public String show() {
         StringBuilder buf = new StringBuilder();
-        if ( imports.size()!=0 ) buf.append(" : "+imports);
+        if (!imports.isEmpty()) buf.append(" : "+imports);
         for (String name : templates.keySet()) {
 			CompiledST c = rawGetTemplate(name);
 			if ( c.isAnonSubtemplate || c==NOT_FOUND_ST ) continue;

--- a/src/org/stringtemplate/v4/compiler/STLexer.java
+++ b/src/org/stringtemplate/v4/compiler/STLexer.java
@@ -185,7 +185,7 @@ public class STLexer implements TokenSource {
 	@Override
 	public Token nextToken() {
 		Token t;
-		if ( tokens.size()>0 ) { t = tokens.remove(0); }
+		if (!tokens.isEmpty()) { t = tokens.remove(0); }
 		else t = _nextToken();
 //		System.out.println(t);
 		return t;

--- a/src/org/stringtemplate/v4/gui/STViz.java
+++ b/src/org/stringtemplate/v4/gui/STViz.java
@@ -213,7 +213,7 @@ public class STViz {
 		viewFrame.output.addCaretListener(caretListenerLabel);
 
         // ADD ERRORS
-        if ( errors==null || errors.size()==0 ) {
+        if ( errors==null || errors.isEmpty()) {
             viewFrame.errorScrollPane.setVisible(false); // don't show unless errors
         }
         else {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155

Please let me know if you have any questions.
Ayman Abdelghany.
