### PR TITLE
[squid:S2259] Null pointers should not be dereferenced

### DIFF
--- a/src/org/stringtemplate/v4/gui/JTreeSTModel.java
+++ b/src/org/stringtemplate/v4/gui/JTreeSTModel.java
@@ -51,6 +51,8 @@ public class JTreeSTModel implements TreeModel {
 
 		@Override
 		public boolean equals(Object o) {
+			if (o == null)
+				return false;
 			//System.out.println(event+"=="+((Wrapper)o).event+" is "+(this.event == ((Wrapper)o).event));
 			return this.event == ((Wrapper)o).event;
 		}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2259 - “Null pointers should not be dereferenced”. 

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2259

Please let me know if you have any questions.
Ayman Abdelghany.
