### PR TITLE
Update Maven build and fix VERSION property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,12 @@
 	<build>
 		<sourceDirectory>src</sourceDirectory>
 		<testSourceDirectory>test</testSourceDirectory>
+		<resources>
+			<resource>
+				<directory>resources</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
 		<testResources>
 			<testResource>
 				<directory>test</directory>

--- a/pom.xml
+++ b/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
@@ -29,6 +30,71 @@
 		template authors.
 	</description>
 
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<java5.home>${env.JAVA5_HOME}</java5.home>
+		<java6.home>${env.JAVA6_HOME}</java6.home>
+		<bootclasspath.java5>${java5.home}/lib/rt.jar</bootclasspath.java5>
+		<bootclasspath.java6>${java6.home}/lib/rt.jar</bootclasspath.java6>
+		<bootclasspath.compile>${bootclasspath.java5}</bootclasspath.compile>
+		<bootclasspath.testCompile>${bootclasspath.java6}</bootclasspath.testCompile>
+	</properties>
+
+	<url>http://www.stringtemplate.org</url>
+	<developers>
+		<developer>
+			<name>Terence Parr</name>
+			<organization>USFCA</organization>
+			<organizationUrl>http://www.cs.usfca.edu</organizationUrl>
+			<email>parrt@antlr.org</email>
+			<roles>
+				<role>Project Leader</role>
+				<role>Developer - Java Target</role>
+			</roles>
+			<timezone>PST</timezone>
+		</developer>
+		<developer>
+			<name>Sam Harwell</name>
+			<organization>Tunnel Vision Laboratories, LLC</organization>
+			<organizationUrl>http://tunnelvisionlabs.com</organizationUrl>
+			<email>sam@tunnelvisionlabs.com</email>
+			<roles>
+				<role>Developer</role>
+			</roles>
+			<timezone>CST</timezone>
+		</developer>
+		<developer>
+			<name>Jim Idle</name>
+			<organization>Temporal Wave LLC</organization>
+			<organizationUrl>http://www.temporal-wave.com</organizationUrl>
+			<email>jimi@temporal-wave.com</email>
+			<roles>
+				<role>Developer - Maven stuff</role>
+			</roles>
+			<timezone>PST</timezone>
+		</developer>
+	</developers>
+
+	<licenses>
+		<license>
+			<name>BSD licence</name>
+			<url>http://antlr.org/license.html</url>
+			<distribution>repo</distribution>
+		</license>
+	</licenses>
+
+	<issueManagement>
+		<system>GitHub Issues</system>
+		<url>https://github.com/antlr/stringtemplate4/issues</url>
+	</issueManagement>
+
+	<scm>
+		<url>git://github.com/antlr/stringtemplate4.git</url>
+		<connection>scm:git:git://github.com/antlr/stringtemplate4.git</connection>
+		<developerConnection>scm:git:git@github.com:antlr/stringtemplate4.git</developerConnection>
+		<tag>HEAD</tag>
+	</scm>
+
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
@@ -44,20 +110,89 @@
 		</dependency>
 	</dependencies>
 
+	<profiles>
+		<profile>
+			<id>sonatype-oss-release</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<executions>
+							<execution>
+								<id>default-compile</id>
+								<configuration>
+									<compilerArguments>
+										<bootclasspath>${bootclasspath.compile}</bootclasspath>
+									</compilerArguments>
+								</configuration>
+							</execution>
+							<execution>
+								<id>default-testCompile</id>
+								<configuration>
+									<compilerArguments>
+										<bootclasspath>${bootclasspath.testCompile}</bootclasspath>
+									</compilerArguments>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-shade-plugin</artifactId>
+						<version>2.2</version>
+						<executions>
+							<execution>
+								<phase>package</phase>
+								<goals>
+									<goal>shade</goal>
+								</goals>
+								<configuration>
+									<minimizeJar>true</minimizeJar>
+									<createDependencyReducedPom>false</createDependencyReducedPom>
+									<shadedArtifactAttached>true</shadedArtifactAttached>
+									<createSourcesJar>true</createSourcesJar>
+									<shadeSourcesContent>true</shadeSourcesContent>
+									<shadedClassifierName>complete</shadedClassifierName>
+									<relocations>
+										<relocation>
+											<pattern>org.antlr</pattern>
+											<shadedPattern>st4hidden.org.antlr</shadedPattern>
+										</relocation>
+									</relocations>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
 	<build>
 		<sourceDirectory>src</sourceDirectory>
 		<testSourceDirectory>test</testSourceDirectory>
+		<testResources>
+			<testResource>
+				<directory>test</directory>
+			</testResource>
+		</testResources>
+
 		<plugins>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>1.8</version>
-			</plugin>
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.12.4</version>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>2.4</version>
+				<configuration>
+					<archive>
+						<manifest>
+							<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+						</manifest>
+					</archive>
+				</configuration>
 			</plugin>
+
 			<plugin>
 				<groupId>org.antlr</groupId>
 				<artifactId>antlr3-maven-plugin</artifactId>
@@ -75,6 +210,98 @@
 					</execution>
 				</executions>
 			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.1</version>
+				<configuration>
+					<sourceDirectory>src</sourceDirectory>
+					<showWarnings>true</showWarnings>
+					<showDeprecation>true</showDeprecation>
+					<compilerArgs>
+						<arg>-Xlint</arg>
+						<arg>-Xlint:-serial</arg>
+					</compilerArgs>
+				</configuration>
+
+				<executions>
+					<execution>
+						<id>default-compile</id>
+						<configuration>
+							<source>1.5</source>
+							<target>1.5</target>
+						</configuration>
+					</execution>
+					<execution>
+						<id>default-testCompile</id>
+						<configuration>
+							<source>1.6</source>
+							<target>1.6</target>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-release-plugin</artifactId>
+				<!-- override the version inherited from the parent -->
+				<version>2.5</version>
+				<configuration>
+					<arguments>-Psonatype-oss-release ${release.arguments}</arguments>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.17</version>
+				<configuration>
+					<systemProperties>
+						<java.io.tmpdir>${project.build.directory}/test-output/</java.io.tmpdir>
+					</systemProperties>
+					<additionalClasspathElements>
+						<additionalClasspathElement>${basedir}/src</additionalClasspathElement>
+					</additionalClasspathElements>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>findbugs-maven-plugin</artifactId>
+				<version>2.5.3</version>
+				<configuration>
+					<findbugsXmlOutput>true</findbugsXmlOutput>
+					<findbugsXmlWithMessages>true</findbugsXmlWithMessages>
+					<xmlOutput>true</xmlOutput>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<!-- override the version inherited from the parent -->
+				<version>2.2.1</version>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<!-- override the version inherited from the parent -->
+				<version>2.9.1</version>
+				<configuration>
+					<quiet>true</quiet>
+				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-gpg-plugin</artifactId>
+				<!-- override the version inherited from the parent -->
+				<version>1.5</version>
+			</plugin>
+
 		</plugins>
 	</build>
 </project>

--- a/resources/org/stringtemplate/v4/version.properties
+++ b/resources/org/stringtemplate/v4/version.properties
@@ -1,0 +1,1 @@
+version=${project.version}

--- a/src/org/stringtemplate/v4/ST.java
+++ b/src/org/stringtemplate/v4/ST.java
@@ -43,6 +43,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
@@ -53,6 +54,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Properties;
 
 /** An instance of the StringTemplate. It consists primarily of
  *  a {@linkplain ST#impl reference} to its implementation (shared among all
@@ -68,7 +70,25 @@ import java.util.Map;
  *  says.</p>
  */
 public class ST {
-	public final static String VERSION = "4.0.8";
+	public final static String VERSION;
+	static {
+		String version;
+		try {
+			Properties properties = new Properties();
+			InputStream inputStream = ST.class.getClassLoader().getResourceAsStream(ST.class.getPackage().getName().replace('.', '/') + "/version.properties");
+			try {
+				properties.load(inputStream);
+			} finally {
+				inputStream.close();
+			}
+
+			version = properties.getProperty("version");
+		} catch (Throwable ex) {
+			version = "4.x";
+		}
+
+		VERSION = version;
+	}
 
 	/** {@code <@r()>}, {@code <@r>...<@end>}, and {@code @t.r() ::= "..."} defined manually by coder */
     public enum RegionType {


### PR DESCRIPTION
- Restore full Maven build support
- Use a properties file to populate `ST.VERSION` accurately (fixes #108)

> :warning: To complete this, one of the following two things needs to happen:
> 1. The Ant build script is updated to copy the **version.properties** resource file and replace `${project.version}` with the appropriate value
> 2. The Ant build script is removed

:question: @parrt Does one of the two approaches listed here work for you? If so, I will go ahead and make the change and update this pull request.
