### PR TITLE
Fix handling of indented comment at end of template

### DIFF
--- a/src/org/stringtemplate/v4/compiler/CodeGenerator.g
+++ b/src/org/stringtemplate/v4/compiler/CodeGenerator.g
@@ -112,6 +112,18 @@ import org.stringtemplate.v4.*;
 	public void func(CommonTree id) { $template::state.func(templateToken, id); }
 	public void refAttr(CommonTree id) { $template::state.refAttr(templateToken, id); }
 	public int defineString(String s) { return $template::state.defineString(s); }
+
+	@Override
+	public void displayRecognitionError(String[] tokenNames, RecognitionException e) {
+		Token tokenWithPosition = e.token;
+		if (tokenWithPosition.getInputStream() == null) {
+			tokenWithPosition = input.getTreeAdaptor().getToken(input.LT(-1));
+		}
+
+		String hdr = getErrorHeader(e);
+		String msg = getErrorMessage(e, tokenNames);
+		errMgr.compileTimeError(ErrorType.SYNTAX_ERROR, templateToken, tokenWithPosition, hdr + " " + msg);
+	}
 }
 
 templateAndEOF : template[null,null] EOF; // hush warning; ignore

--- a/src/org/stringtemplate/v4/compiler/CodeGenerator.g
+++ b/src/org/stringtemplate/v4/compiler/CodeGenerator.g
@@ -157,7 +157,7 @@ chunk
 element
 	:	^(INDENTED_EXPR INDENT compoundElement[$INDENT]) // ignore indent in front of IF and region blocks
 	|	compoundElement[null]
-	|	^(INDENTED_EXPR INDENT {$template::state.indent($INDENT);} singleElement {$template::state.emit(Bytecode.INSTR_DEDENT);})
+	|	^(INDENTED_EXPR INDENT {$template::state.indent($INDENT);} singleElement? {$template::state.emit(Bytecode.INSTR_DEDENT);})
 	|	singleElement
 	;
 

--- a/test/org/stringtemplate/v4/test/TestGroupSyntax.java
+++ b/test/org/stringtemplate/v4/test/TestGroupSyntax.java
@@ -37,6 +37,7 @@ import org.stringtemplate.v4.misc.Misc;
 import java.io.File;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class TestGroupSyntax extends BaseTest {
     @Test public void testSimpleGroup() throws Exception {
@@ -301,5 +302,30 @@ public class TestGroupSyntax extends BaseTest {
 						  " context [/main /f] 1:1 attribute x isn't defined]";
 		String result = errors.errors.toString();
 		assertEquals(expected, result);
+	}
+
+	/**
+	 * This is a regression test for antlr/stringtemplate4#138.
+	 */
+	@Test public void testIndentedComment() throws Exception {
+		String templates =
+			"t() ::= <<" + Misc.newline +
+			"  <! a comment !>" + Misc.newline +
+			">>" + Misc.newline;
+
+		writeFile(tmpdir, "t.stg", templates);
+		ErrorBuffer errors = new ErrorBuffer();
+		STGroup group = new STGroupFile(tmpdir+"/"+"t.stg");
+		group.setListener(errors);
+		ST template = group.getInstanceOf("t");
+
+		assertEquals("[]", errors.errors.toString());
+		assertNotNull(template);
+
+		String expected = "";
+		String result = template.render();
+		assertEquals(expected, result);
+
+		assertEquals("[]", errors.errors.toString());
 	}
 }


### PR DESCRIPTION
- Make sure errors in **CodeGenerator.g** get reported to listeners
- Fix handling of indented comment at end of template

Fixes #138 
