### PR TITLE
Fix typos in introductory documentation

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -53,3 +53,4 @@ YYYY/MM/DD, github id, Full name, email
 2015/05/28, jsnyders, John Snyders, jjsnyders at rcn.com
 2015/12/07, sharwell, Sam Harwell, sam@tunnelvisionlabs.com
 2016/07/18, jeff5, Jeff Allen, ja.py@farowl.co.uk
+2016/08/23, BurtHarris, Burt Harris, Burt_Harris.github@azxs.33mail.com

--- a/contributors.txt
+++ b/contributors.txt
@@ -52,3 +52,4 @@ YYYY/MM/DD, github id, Full name, email
 2012/08/13, pgelinas, Pascal Gélinas, pascal.gelinas@polymtl.ca
 2015/05/28, jsnyders, John Snyders, jjsnyders at rcn.com
 2015/12/07, sharwell, Sam Harwell, sam@tunnelvisionlabs.com
+2016/07/18, jeff5, Jeff Allen, ja.py@farowl.co.uk

--- a/doc/groups.md
+++ b/doc/groups.md
@@ -47,7 +47,7 @@ Templates with the same name override templates from imported groups just like m
 
 ## Dictionaries
 
-There are situations where you need to translate a string in one language to a string in another language. For example, you might want to translate integer to int when translating Pascal to C. You could pass a Map or IDictionary (e.g. hashtable) from the model into the templates, but then you have output literals in your model!& The StringTemplate solution is to support a dictionary feature. For example, here is a dictionary that maps Java type names to their default initialization values:
+There are situations where you need to translate a string in one language to a string in another language. For example, you might want to translate integer to int when translating Pascal to C. You could pass a Map or IDictionary (e.g. hashtable) from the model into the templates, but then you have output literals in your model:-1:. The StringTemplate solution is to support a dictionary feature. For example, here is a dictionary that maps Java type names to their default initialization values:
 
 ```
 typeInitMap ::= [
@@ -73,7 +73,7 @@ The default and other mappings cannot have empty values. They have empty values 
 
 Dictionaries are defined in the group's scope and are visible if no attribute hides them. For example, if you define a formal argument called typeInitMap in template foo then foo cannot see the map defined in the group (though you could pass it in as another parameter). If a name is not an attribute and it's not in the group's maps table, then any imported groups are consulted. You may not redefine a dictionary and it may not have the same name as a template in that group. The default clause must be at the end of the map.
 
-You'll note that the square brackets will denote data structure in other areas too such as `[a,b,c,...]` which makes a singe multi-valued attribute out of other attributes so you can iterate across them.
+You'll notice that square brackets denote data structure in other areas too such as `[a,b,c,...]` which makes a singe multi-valued attribute out of other attributes so you can iterate across them.
 
 ## Template definitions
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -2,7 +2,7 @@
 
 Please check [Frequently asked questions (FAQ)](faq/index.md) before asking questions on stackoverflow or StringTemplate-discussion list.
 
-Notes: To add to or improve this documentation, <a href=https://help.github.com/articles/fork-a-repo>fork</a> the <a href=https://github.com/antlr/stringtemplate4>antlr/stringtemplate4 repo</a> then update this `doc/index.md` or file(s) in that directory.  Submit a <a href=https://help.github.com/articles/creating-a-pull-request>pull request</a> to get your changes incorporated into the main repository. Do not mix code and documentation updates in the sample pull request. <b>You must sign the contributors.txt certificate of origin with your pull request if you've not done so before.</b></li>
+Notes: To add to or improve this documentation, <a href=https://help.github.com/articles/fork-a-repo>fork</a> the <a href=https://github.com/antlr/stringtemplate4>antlr/stringtemplate4 repo</a> then update this `doc/index.md` or file(s) in that directory.  Submit a <a href=https://help.github.com/articles/creating-a-pull-request>pull request</a> to get your changes incorporated into the main repository. Do not mix code and documentation updates in the same pull request. <b>You must sign the contributors.txt certificate of origin with your pull request if you've not done so before.</b></li>
 
 ## Installation
 

--- a/doc/introduction.md
+++ b/doc/introduction.md
@@ -4,13 +4,13 @@ First, to learn more about StringTemplate's philosophy, you can check out the ve
 
 Most programs that emit source code or other text output are unstructured blobs of generation logic interspersed with print statements. The primary reason is the lack of suitable tools and formalisms. The proper formalism is that of an output grammar because you are not generating random characters--you are generating sentences in an output language. This is analogous to using a grammar to describe the structure of input sentences. Rather than building a parser by hand, most programmers will use a parser generator. Similarly, we need some form of *unparser generator* to generate text. The most convenient manifestation of the output grammar is a template engine such as StringTemplate.
 
-A template engine is simply a code generator that emits text using templates, which are really just "documents with holes" in them where you can stick values called attributes. An attribute is either a program object such as a string or VarSymbol object, a template instance, or sequence of attributes including other sequences. Template engines are domain-specific languages for generating structured text. StringTemplate breaks up your template into chunks of text and attribute expressions, which are by default enclosed in angle brackets <attribute-expression> (but you can use whatever single character start and stop delimiters you want). StringTemplate ignores everything outside of attribute expressions, treating it as just text to spit out. To evaluate a template and generate text, we "render" it with a method call:
+A template engine is simply a code generator that emits text using templates, which are really just documents with "holes" in them where you can stick values called attributes. An attribute is either a program object such as a string or `VarSymbol` object, a template instance, or a sequence of attributes including other sequences. Template engines are domain-specific languages for generating structured text. StringTemplate breaks up your template into chunks of text and attribute expressions, which are by default enclosed in angle brackets <attribute-expression> (but you can use whatever single character start and stop delimiters you want). StringTemplate ignores everything outside of attribute expressions, treating it as just text to spit out. To evaluate a template and generate text, we "render" it with a method call:
 
 ```java
 ST.render()
 ```
 
-For example, the following template has two chunks, a literal and a reference to attribute name:
+For example, the following template has two chunks, a literal and a reference to attribute `name`:
 
 ```
 Hello, <name>
@@ -68,11 +68,11 @@ If you would like to keep just the template text and not the formal template def
 
 That makes it easier for graphics designers and HTML people to work with template files, although the formal parameter definitions are okay for people using these to generate source code as they will usually be programmers not graphics people.
 
-This example demonstrates some key syntax and features. Template definitions look very similar to function definitions except that the bodies are strings. Template decl takes three arguments by reference as only two of them directly. Instead of expanding value immediately, invokes/includes template init instead with an argument of value. Alternatively, Template init could take no arguments. It would still see attribute value though because of *dynamic scoping*. That essentially means that a template can reference the attributes of any invoking template.
+This example demonstrates some key syntax and features. Template definitions look very similar to function definitions except that the bodies are strings. Template `decl` takes three arguments by reference but uses only two of them directly. Instead of expanding `value` immediately, it invokes/includes template `init` with `value` as the argument. Alternatively, template `init` could be given no arguments, and it would still see attribute `value` because of *dynamic scoping*. That essentially means that a template can reference the attributes of any invoking template.
 
-Note, that to get the spacing correct, there is no space between expression `<name>` and `<init()>`. If we do not inject a declaration initialization (attribute value), we don't want to space between the name and the `;`. Template init emits ` = <v>` only if the controller code injects a value, which we do here (0). In this case, we have injected two strings and one integer, but we can send in any object we want; more on that below.
+Note, that to get the spacing correct, there is no space between expression `<name>` and `<init()>`. If we do not inject a declaration initialization (attribute value), we don't want to space between the name and the `;`. Template `init` emits ` = <v>` only if the controller code injects a value, which we do here (0). In this case, we have injected two strings and one integer, but we can send in any object we want; more on that below.
 
-Sometimes it's more convenient to collect templates together into a single unit called the group file. For example, we can collected the template .st files into a single .stg group file:
+Sometimes it's more convenient to collect templates together into a single unit called the group file. For example, we can collect the definitions in the separate template .st files into an equivalent .stg group file:
 
 ```
 // file /tmp/test.stg

--- a/doc/introduction.md
+++ b/doc/introduction.md
@@ -36,7 +36,7 @@ StringTemplate is not a "system" or "engine" or "server". It is designed to be e
 
 The primary classes of interest are `ST`, `STGroupDir`, and `STGroupFile`. You can directly create a template in code, you can load templates from a directory, and you can load a file containing a collection templates (a template group file). Group files behave like zips or jars of template directories.
 
-For example, let's assume we have two templates in files decl.st and init.st in directory /tmp:
+For example, let's assume we have two templates in files `decl.st` and `init.st` in directory `/tmp`:
 
 ```
 // file /tmp/decl.st
@@ -48,7 +48,7 @@ decl(type, name, value) ::= "<type> <name><init(value)>;"
 init(v) ::= "<if(v)> = <v><endif>"
 ```
 
-We can access those templates by creating a STGroupDir object. We then ask for an instance with getInstanceOf() and inject attributes with add():
+We can access those templates by creating a `STGroupDir` object. We then ask for an instance with `getInstanceOf()` and inject attributes with `add()`:
  
 ```java
 STGroup group = new STGroupDir("/tmp");
@@ -59,7 +59,7 @@ st.add("value", 0);
 String result = st.render(); // yields "int x = 0;"
 ```
 
-If you would like to keep just the template text and not the formal template definition around the template text, you can use STRawGroupDir. Then, decl.st would hold just the following:
+If you would like to keep just the template text and not the formal template definition around the template text, you can use `STRawGroupDir`. Then, `decl.st` would hold just the following:
 
 ```
 // file /tmp/decl.st
@@ -72,7 +72,7 @@ This example demonstrates some key syntax and features. Template definitions loo
 
 Note, that to get the spacing correct, there is no space between expression `<name>` and `<init()>`. If we do not inject a declaration initialization (attribute value), we don't want to space between the name and the `;`. Template `init` emits ` = <v>` only if the controller code injects a value, which we do here (0). In this case, we have injected two strings and one integer, but we can send in any object we want; more on that below.
 
-Sometimes it's more convenient to collect templates together into a single unit called the group file. For example, we can collect the definitions in the separate template .st files into an equivalent .stg group file:
+Sometimes it's more convenient to collect templates together into a single unit called the group file. For example, we can collect the definitions in the separate template `.st` files into an equivalent `.stg` group file:
 
 ```
 // file /tmp/test.stg
@@ -80,7 +80,7 @@ decl(type, name, value) ::= "<type> <name><init(value)>;"
 init(v) ::= "<if(v)> = <v><endif>"
 ```
 
-To pull templates from this file instead of a directory, all we have to do is change our constructor to use STGroupFile:
+To pull templates from this file instead of a directory, all we have to do is change our constructor to use `STGroupFile`:
  
 ```java
 STGroup group = new STGroupFile("/tmp/test.stg");
@@ -107,7 +107,7 @@ public static class User {
 }
 ```
  
-We can inject instances of `User` just like predefined objects like strings and can refer to properties using the `.` dot property access operator. StringTemplate interprets `o.p` by looking for property `p` within object `o`. The lookup rules differ slightly between language ports, but in general they follow the old JavaBeans naming convention. StringTemplate looks for methods `getP()`, `isP()`, `hasP()` first. If it fails to find one of those methods, it looks for a field called `p`. In the following example, we access properties id and name. Also note that the template uses `$...$` delimiters, which makes more sense since we are generating HTML.
+We can inject instances of `User` just like predefined objects like strings and can refer to properties using the `.` dot property access operator. StringTemplate interprets `o.p` by looking for property `p` within object `o`. The lookup rules differ slightly between language ports, but in general they follow the old JavaBeans naming convention. StringTemplate looks for methods `getP()`, `isP()`, `hasP()` first. If it fails to find one of those methods, it looks for a field called `p`. In the following example, we access properties `id` and `name`. Also note that the template uses `$...$` delimiters, which makes more sense since we are generating HTML.
  
 ```java
 ST st = new ST("<b>$u.id$</b>: $u.name$", '$', '$');
@@ -121,7 +121,7 @@ StringTemplate renders all injected attributes and any reference properties to t
 
 ### Injecting data aggregate attributes
 
-Being able to pass in objects and access their fields is very convenient but often we don't have a handy object to inject. Creating one-off data aggregates is a pain, you have to define a new class just to associate two pieces of data. StringTemplate makes it easy to group data during add() calls. You may pass in an aggregrate attribute name to add() with the data to aggregate. The syntax of the attribute name describes the properties. For example `a.{p1,p2,p3}` describes an attribute called a that has three properties `p1`, `p2`, `p3`. Here's an example:
+Being able to pass in objects and access their fields is very convenient but often we don't have a handy object to inject. Creating one-off data aggregates is a pain, you have to define a new class just to associate two pieces of data. StringTemplate makes it easy to group data during `add()` calls. You may pass in an aggregrate attribute name to `add()` with the data to aggregate. The syntax of the attribute name describes the properties. For example `a.{p1,p2,p3}` describes an attribute called a that has three properties `p1`, `p2`, `p3`. Here's an example:
 
  
 ```java

--- a/doc/introduction.md
+++ b/doc/introduction.md
@@ -144,14 +144,16 @@ test(name) ::= "<name:bracket()>" // apply bracket template to each name
 bracket(x) ::= "[<x>]"            // surround parameter with square brackets
 ```
 
-Injecting our list of names as attribute name into template test yields `[parrt][tombu]`. Combining with the separator operator yields `[parrt], [tombu]`:
+Injecting our list of names as attribute name into template test yields `[parrt][tombu]`. StringTemplate sets the first parameter of the template it's applying (`x` in this case) to the iterated value.
+
+Combining with the separator operator yields `[parrt], [tombu]`:
 
 ```
 test(name) ::= "<name:bracket(); separator=\", \">"
 bracket(x) ::= "[<x>]"
 ```
 
-StringTemplate is dynamically typed in the sense that it doesn't care about the types of the elements except when we access properties. For example, we could pass in a list of `User` objects, `User(999,"parrt")` and `User(1000,"tombu")`, and the templates would work without alteration. StringTemplate would use the "to string" evaluation function appropriate for the implementation language to evaluate `<x>`. The output we'd get is `[999:parrt], [1000:tombu]`. StringTemplate sets the first parameter of the template it's applying to the iterated value (`x` in this case).
+StringTemplate is dynamically typed in the sense that it doesn't care about the types of the elements except when we access properties. For example, we could pass in a list of `User` objects, `User(999,"parrt")` and `User(1000,"tombu")`, and the templates would work without alteration. StringTemplate would use the "to string" evaluation function appropriate for the implementation language to evaluate `<x>`. The output we'd get is `[999:parrt], [1000:tombu]`.
 
 Sometimes creating a separate template definition is too much effort for a one-off template or a really small one. In those cases, we can use anonymous templates (or subtemplates). Anonymous templates are templates without a name enclosed in curly braces. They can have arguments, though, just like a regular template. For example, we can redo the above example as follows.
 
@@ -163,7 +165,8 @@ Anonymous template `{x | [<x>]}` is the in-lined version of `bracket()`. Argumen
 
 StringTemplate will iterate across any object that it can reasonably interpret as a collection of elements such as arrays, lists, dictionaries and, in statically typed ports, objects satisfying iterable or enumeration interfaces.
 
-General use of StringTemplate for formatting
+### General use of StringTemplate for formatting
+
 The `ST.format()` method is great for general use in general code.
 
 ```java


### PR DESCRIPTION
As I read the introductory documentation I noticed a few typos and the odd place where the meaning was obscure to a beginner. I guess these parts don't get much attention from those who've already mastered StringTemplate so I thought I'd pitch in while I'm uniquely qualified.

Other changes are back-tick quoting in-line code in what seems to be the house style (but also helps readability).

The worst garble I found is already covered by #134, so I haven't duplicated that fix.
