### PR TITLE
Fix table in null-vs-empty.md

### DIFF
--- a/doc/null-vs-empty.md
+++ b/doc/null-vs-empty.md
@@ -18,7 +18,7 @@ This table shows the result of evaluating the indicated expression given the val
 |`<x:t()>`|	""|	""|	""	|""|
 |`<x; null="y">`|	y	|y|	""|	""|
 |`<x:t(); null="y">`	|y|	y|	""|	""|
-|`<if(x)>y<endif>`	""|	""|	y	|""|
+|`<if(x)>y<endif>`	|""|	""|	y	|""|
 |`<if(x)>y<else>z<endif>`	|z|	z|	y|	z|
 
 For that, I assume that x.y where x and/or y are undefined is also considered the same as plain x is undefined or null.
@@ -36,11 +36,11 @@ We must distinguish between a list, array, or other Iteratable passed in as an a
 |`<x; separator=",">`     |""|    a|      a,b|    ""|     b|      a|      a,b|
 |`<x; null="y", separator=",">`|  ""|     a|      a,b|    y|      y,b|    a,y|    a,y,b|
 |`<if(x)>y<endif>`|       ""|     y|      y|      y|      y|      y|      y|
-|`<x:{it | <it>}>`|       ""|     a|      ab|     ""|     b|      a|      ab|
-|`<x:{it | <it>}; null="y">`|     ""|     y|      ab|     y|      yb|     ay|  ayb|
-|`<x:{it | <i>.<it>}>`|   ""|     1.a|    1.a2.b  |""|    1.b|    1.a|    1.a2.b|
-|`<x:{it | <i>.<it>}; null="y">`| ""|     1.a|    1.a2.b| y|      y2.b|   1.ay|   1.ay3.b|
-|`<x:{it | x<if(!it)>y<endif>}; null="z">`|       ""|     x|      xx|     z|      zx|     xz|     xzx|
+|`<x:{it \| <it>}>`|       ""|     a|      ab|     ""|     b|      a|      ab|
+|`<x:{it \| <it>}; null="y">`|     ""|     y|      ab|     y|      yb|     ay|  ayb|
+|`<x:{it \| <i>.<it>}>`|   ""|     1.a|    1.a2.b  |""|    1.b|    1.a|    1.a2.b|
+|`<x:{it \| <i>.<it>}; null="y">`| ""|     1.a|    1.a2.b| y|      y2.b|   1.ay|   1.ay3.b|
+|`<x:{it \| x<if(!it)>y<endif>}; null="z">`|       ""|     x|      xx|     z|      zx|     xz|     xzx|
 |`<x:t():u(); null={y}>`| ""|      a|      ab|     y|      yb|     ay|     ayb|
 
 Notice that a null value never gets passed as the iterated value.  Subtemplates are not applied to empty values. The null option is evaluated for null elements.
@@ -58,9 +58,9 @@ Ok, now let's look at [...] list construction within ST expressions. [...] cats 
 |----|----|----|
 |`<[]>`|	""|	list is empty, yields empty string|
 |`<[]; null="x">`|	""	|list is empty; no null element => no x|
-|`<[[],[]]:{it | <if(it)>x<endif>}; separator=",">`|	""	|`[[],[]]` collapses to `[]`|
+|`<[[],[]]:{it \| <if(it)>x<endif>}; separator=",">`|	""	|`[[],[]]` collapses to `[]`|
 |`<[]:t()>`	|""	|nothing to apply; template not evaluated|
-|`<[]:{it | <if(it)>x<endif>}>`|	""	|nothing to apply; template not evaluated|
+|`<[]:{it \| <if(it)>x<endif>}>`|	""	|nothing to apply; template not evaluated|
 
 Any missing map entry evaluates to null.
 For dictionary `d ::= [x:"x"]`, `<d.(x):{it | <it>}>` is `x` and `<d.(y):{it | <it>}>` is `""`.


### PR DESCRIPTION
Vertical bars used in inline code blocks still need to be escaped with a backslash, otherwise the table formatting will break.