### PR TITLE
resolved Issue #98 ArrayIndexOutOfBoundsException 

### DIFF
--- a/src/org/stringtemplate/v4/compiler/CompiledST.java
+++ b/src/org/stringtemplate/v4/compiler/CompiledST.java
@@ -204,8 +204,8 @@ public class CompiledST implements Cloneable {
 		if ( formalArguments==null ) {
 			formalArguments = Collections.synchronizedMap(new LinkedHashMap<String,FormalArgument>());
 		}
-		a.index = formalArguments.size();
 		formalArguments.put(a.name, a);
+		a.index = formalArguments.size() -1;
 	}
 
 	public void defineImplicitlyDefinedTemplates(STGroup group) {


### PR DESCRIPTION
issue [#98 ](https://github.com/antlr/stringtemplate4/issues/98)
We are using ST for a few years on our 600 machines cluster and always had this exception on some of them. The problem seems to be an insert of a key that already exists in the map, then the map size is the same => 'local' array length is the the same as the map but the index does increment. reversed order of increment index and insert key in CompiledST seems to resolve the issue.