### PR TITLE
Add NO_SUCH_ATTRIBUTE to list of ignored runtime errors

### DIFF
--- a/src/org/stringtemplate/v4/misc/ErrorBuffer.java
+++ b/src/org/stringtemplate/v4/misc/ErrorBuffer.java
@@ -43,7 +43,7 @@ public class ErrorBuffer implements STErrorListener {
 
 	@Override
     public void runTimeError(STMessage msg) {
-        if ( msg.error != ErrorType.NO_SUCH_PROPERTY ) { // ignore these
+        if ( msg.error != ErrorType.NO_SUCH_PROPERTY && msg.error != ErrorType.NO_SUCH_ATTRIBUTE ) { // ignore these
             errors.add(msg);
         }
     }

--- a/src/org/stringtemplate/v4/misc/ErrorManager.java
+++ b/src/org/stringtemplate/v4/misc/ErrorManager.java
@@ -45,7 +45,7 @@ public class ErrorManager {
 
 			@Override
             public void runTimeError(STMessage msg) {
-                if ( msg.error != ErrorType.NO_SUCH_PROPERTY ) { // ignore these
+                if ( msg.error != ErrorType.NO_SUCH_PROPERTY && msg.error != ErrorType.NO_SUCH_ATTRIBUTE ) { // ignore these
                     System.err.println(msg);
                 }
             }

--- a/test/org/stringtemplate/v4/test/TestGroupSyntax.java
+++ b/test/org/stringtemplate/v4/test/TestGroupSyntax.java
@@ -296,9 +296,7 @@ public class TestGroupSyntax extends BaseTest {
 		ST st = group.getInstanceOf("main");
 		st.render();
 
-		String expected = "[context [/main] 1:1 attribute x isn't defined," +
-						  " context [/main] 1:1 passed 1 arg(s) to template /f with 0 declared arg(s)," +
-						  " context [/main /f] 1:1 attribute x isn't defined]";
+		String expected = "[context [/main] 1:1 passed 1 arg(s) to template /f with 0 declared arg(s)]";
 		String result = errors.errors.toString();
 		assertEquals(expected, result);
 	}

--- a/test/org/stringtemplate/v4/test/TestGroups.java
+++ b/test/org/stringtemplate/v4/test/TestGroups.java
@@ -540,7 +540,7 @@ public class TestGroups extends BaseTest {
 		group.setListener(errors);
 		ST st = group.getInstanceOf("g");
 		st.render();
-		String expected = "context [/g] 1:1 attribute z isn't defined"+newline;
+		String expected = "";
 		String result = errors.toString();
 		assertEquals(expected, result);
 	}

--- a/test/org/stringtemplate/v4/test/TestInterptimeErrors.java
+++ b/test/org/stringtemplate/v4/test/TestInterptimeErrors.java
@@ -183,7 +183,7 @@ public class TestInterptimeErrors extends BaseTest {
 		group.setListener(errors);
         ST st = group.getInstanceOf("t");
         st.render();
-        String expected = "context [/t /u] 1:1 attribute x isn't defined"+newline;
+        String expected = "";
 		String result = errors.toString();
         assertEquals(expected, result);
     }

--- a/test/org/stringtemplate/v4/test/TestScopes.java
+++ b/test/org/stringtemplate/v4/test/TestScopes.java
@@ -1,6 +1,5 @@
 package org.stringtemplate.v4.test;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.stringtemplate.v4.*;
 import org.stringtemplate.v4.misc.*;
@@ -43,7 +42,6 @@ public class TestScopes extends BaseTest {
 		assertEquals(expectedError, errors.toString());
 	}
 
-	@Ignore
 	@Test public void testUnknownAttr() throws Exception {
 		String templates =
 			"t() ::= \"<x>\"\n";

--- a/test/org/stringtemplate/v4/test/TestScopes.java
+++ b/test/org/stringtemplate/v4/test/TestScopes.java
@@ -1,5 +1,6 @@
 package org.stringtemplate.v4.test;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.stringtemplate.v4.*;
 import org.stringtemplate.v4.misc.*;
@@ -42,6 +43,7 @@ public class TestScopes extends BaseTest {
 		assertEquals(expectedError, errors.toString());
 	}
 
+	@Ignore
 	@Test public void testUnknownAttr() throws Exception {
 		String templates =
 			"t() ::= \"<x>\"\n";
@@ -52,7 +54,7 @@ public class TestScopes extends BaseTest {
 		ST st = group.getInstanceOf("t");
 		String result = st.render();
 
-		String expectedError = "context [/t] 1:1 attribute x isn't defined"+newline;
+		String expectedError = "";
 		assertEquals(expectedError, errors.toString());
 	}
 


### PR DESCRIPTION
For #178

I don't love this pattern and would prefer something in the spirit of log levels. I'm not sure at this time how difficult that would be to implement but it looks like it might be a huge pain.