### PR TITLE
Utf template fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,10 @@
 		template authors.
 	</description>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>junit</groupId>
@@ -57,6 +61,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.12.4</version>
+                <configuration>
+                    <argLine>-Dfile.encoding=UTF-8</argLine>
+                </configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.antlr</groupId>

--- a/src/org/stringtemplate/v4/STGroup.java
+++ b/src/org/stringtemplate/v4/STGroup.java
@@ -568,7 +568,7 @@ public class STGroup {
 			if ( fileURL!=null ) {
 				try {
 					InputStream s = fileURL.openStream();
-					ANTLRInputStream templateStream = new ANTLRInputStream(s);
+					ANTLRInputStream templateStream = new ANTLRInputStream(s,encoding);
 					templateStream.name = fileName;
 					CompiledST code = g.loadTemplateFile("/", fileName, templateStream);
 					if ( code==null ) g = null;

--- a/test/org/stringtemplate/v4/test/TestImports.java
+++ b/test/org/stringtemplate/v4/test/TestImports.java
@@ -422,6 +422,27 @@ public class TestImports extends BaseTest {
 		assertEquals(expected, result);
 	}
 
+    	@Test public void testImportUtfTemplateFileSameDir() throws Exception {
+		/*
+		dir
+			group1.stg		(that imports c.st)
+			c.st
+		 */
+		String dir = getRandomDir();
+		String groupFile =
+			"import \"c.st\"\n" +
+			"a() ::= \"g1 a\"\n"+
+			"b() ::= \"<c()>\"\n";
+		writeFile(dir, "group1.stg", groupFile);
+		writeFile(dir, "c.st", "c() ::= \"2∏r\"\n");
+
+		STGroup group1 = new STGroupFile(dir+"/group1.stg");
+		ST st = group1.getInstanceOf("c"); // should see c()
+		String expected = "2∏r";
+		String result = st.render();
+		assertEquals(expected, result);
+	}
+
 	@Test public void testImportTemplateFileSameDir() throws Exception {
 		/*
 		dir


### PR DESCRIPTION
Bug report #205 contains a test showing that templates containing utf-8/non-ascii characters are not read correctly. I've changed STGroup to add encoding to the ANTLRInputStream creation. I've also added a UTF-8 directive to the pom file because surefire was still failing the test. 