### PR TITLE
Fixed typo in doc/templates.md.

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -57,3 +57,4 @@ YYYY/MM/DD, github id, Full name, email
 2018/11/06, drealeed , Drea Leed, drealeed2@yahoo.com
 2018/11/08, leonlee, Leon Lee, blackicebird@gmail.com
 2018/11/11, adityanarkar, Aditya Narkar, aditya.narkar25@gmail.com
+2019/01/21, cfraizer, Colin Frazier, colin.fraizer@gmail.com

--- a/doc/templates.md
+++ b/doc/templates.md
@@ -35,7 +35,7 @@ StringTemplate has the following literals.
 |`\\`|Ignore the immediately following newline char. Allows you to put a newline in the template to better format it without actually inserting a newline into the output|
 |`"`*string*`"`|A string of output characters|
 |`{`*template*`}`|An anonymous subtemplate|
-|`{`*args* `|` *template*`}`|An anonymous subtemplate with arguments|
+|`{`*args* `\|` *template*`}`|An anonymous subtemplate with arguments|
 |`[]`|An an empty list.|
 |`[`*expr1*`,` *expr2*`,` ...`,` *exprN*`]`|A list with N values. It behaves like an array or list injected from controller code.|
 


### PR DESCRIPTION
Markdown table in documentation did not render properly. Now it does.