### PR TITLE
Fix inheritance example

### DIFF
--- a/doc/inheritance.md
+++ b/doc/inheritance.md
@@ -28,7 +28,7 @@ class <name> {
  
 constants(typename, names) ::= "<names:{n | <constant(n,i)>}; separator={<\n>}>"
  
-constant(n) ::= "public static final int <typename>_<n>=<i>;"
+constant(n, i) ::= "public static final int <typename>_<n>=<i>;"
 ```
 
 Instead of copying and altering the entire group for Java 1.5, we can import the 1.4 group and alter just the part that changes, template `constants`:


### PR DESCRIPTION
Missing argument in Java1_4.stg example:
context [/class /constants /_sub1] 1:13 passed 2 arg(s) to template /constant with 1 declared arg(s)
	at org.stringtemplate.bazel.STRules.process(STRules.java:289)
	at org.stringtemplate.bazel.STRules.main(STRules.java:68)