### PR TITLE
Use an AtomicInteger for subtemplateCount to avoid race condition

### DIFF
--- a/src/org/stringtemplate/v4/compiler/Compiler.java
+++ b/src/org/stringtemplate/v4/compiler/Compiler.java
@@ -27,6 +27,7 @@
  */
 package org.stringtemplate.v4.compiler;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import org.antlr.runtime.ANTLRStringStream;
 import org.antlr.runtime.CommonTokenStream;
 import org.antlr.runtime.NoViableAltException;
@@ -86,7 +87,7 @@ public class Compiler {
     };
 
 	/** Name subtemplates {@code _sub1}, {@code _sub2}, ... */
-	public static int subtemplateCount = 0;
+	public static AtomicInteger subtemplateCount = new AtomicInteger(0);
 
 	public STGroup group;
 
@@ -188,8 +189,8 @@ public class Compiler {
 	}
 
 	public static String getNewSubtemplateName() {
-		subtemplateCount++;
-		return SUBTEMPLATE_PREFIX+subtemplateCount;
+		int count = subtemplateCount.incrementAndGet();
+		return SUBTEMPLATE_PREFIX+count;
 	}
 
 	protected void reportMessageAndThrowSTException(TokenStream tokens, Token templateToken,

--- a/test/org/stringtemplate/v4/test/BaseTest.java
+++ b/test/org/stringtemplate/v4/test/BaseTest.java
@@ -27,6 +27,7 @@
 */
 package org.stringtemplate.v4.test;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import org.antlr.runtime.ANTLRStringStream;
 import org.antlr.runtime.CommonTokenStream;
 import org.antlr.runtime.Token;
@@ -119,7 +120,7 @@ public abstract class BaseTest {
     @Before
     public void setUp() {
         STGroup.defaultGroup = new STGroup();
-        Compiler.subtemplateCount = 0;
+        Compiler.subtemplateCount = new AtomicInteger(0);
 
         String baseTestDirectory = System.getProperty("java.io.tmpdir");
         String testDirectory = getClass().getSimpleName() + "-" + System.currentTimeMillis();


### PR DESCRIPTION
Right now, the way subtemplateCount is implemented is not thread safe
since the ++ operator in java does not atomically read and write the
incremented integer value. Even if each thread gets it's own STGroup, etc. we can get race conditions since the subtemplateCount field is static. This can lead to a template redefinition since a given thread may read the same for the integer twice, causing two subtemplates to have the same generated name if another thread reads the value before and writes the stale value afterwards.

I tracked this down while debugging an issue which spit out the error message like:
``` 
common.stg 8:125: redefinition of template SUBTEMPLATE
``` 

There are similar reports in https://github.com/antlr/stringtemplate4/issues/61

