### PR TITLE
Remove double-brace initialization and wrap constant collections in Collection.unmodifiable{Set,Map}

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -59,3 +59,4 @@ YYYY/MM/DD, github id, Full name, email
 2018/11/11, adityanarkar, Aditya Narkar, aditya.narkar25@gmail.com
 2019/01/21, cfraizer, Colin Frazier, colin.fraizer@gmail.com
 2019/09/09, seanabraham, Sean Abraham, Sean.A208@gmail.com
+2019/12/22, Clashsoft, Adrian Kunz, clashsoft at hotmail dot com

--- a/src/org/stringtemplate/v4/DateRenderer.java
+++ b/src/org/stringtemplate/v4/DateRenderer.java
@@ -38,25 +38,28 @@ import java.util.*;
  * {@code "time:"} shows only those components of the time object.
  */
 public class DateRenderer implements AttributeRenderer {
-    public static final Map<String,Integer> formatToInt =
-        new HashMap<String,Integer>() {
-            {
-                put("short", DateFormat.SHORT);
-                put("medium", DateFormat.MEDIUM);
-                put("long", DateFormat.LONG);
-                put("full", DateFormat.FULL);
+    public static final Map<String, Integer> formatToInt;
 
-                put("date:short", DateFormat.SHORT);
-                put("date:medium", DateFormat.MEDIUM);
-                put("date:long", DateFormat.LONG);
-                put("date:full", DateFormat.FULL);
+    static {
+        final Map<String, Integer> map = new HashMap<String, Integer>();
 
-                put("time:short", DateFormat.SHORT);
-                put("time:medium", DateFormat.MEDIUM);
-                put("time:long", DateFormat.LONG);
-                put("time:full", DateFormat.FULL);
-            }
-        };
+        map.put("short", DateFormat.SHORT);
+        map.put("medium", DateFormat.MEDIUM);
+        map.put("long", DateFormat.LONG);
+        map.put("full", DateFormat.FULL);
+
+        map.put("date:short", DateFormat.SHORT);
+        map.put("date:medium", DateFormat.MEDIUM);
+        map.put("date:long", DateFormat.LONG);
+        map.put("date:full", DateFormat.FULL);
+
+        map.put("time:short", DateFormat.SHORT);
+        map.put("time:medium", DateFormat.MEDIUM);
+        map.put("time:long", DateFormat.LONG);
+        map.put("time:full", DateFormat.FULL);
+
+        formatToInt = Collections.unmodifiableMap(map);
+    }
 
 	@Override
     public String toString(Object o, String formatString, Locale locale) {

--- a/src/org/stringtemplate/v4/Interpreter.java
+++ b/src/org/stringtemplate/v4/Interpreter.java
@@ -820,9 +820,7 @@ public class Interpreter {
 	}
 
 	protected void map(InstanceScope scope, Object attr, final ST st) {
-		final List<ST> prototypes = new ArrayList<ST>();
-		prototypes.add(st);
-		rot_map(scope, attr, prototypes);
+		rot_map(scope, attr, Collections.singletonList(st));
 	}
 
 	/**

--- a/src/org/stringtemplate/v4/Interpreter.java
+++ b/src/org/stringtemplate/v4/Interpreter.java
@@ -59,8 +59,14 @@ public class Interpreter {
 	public enum Option { ANCHOR, FORMAT, NULL, SEPARATOR, WRAP }
 	public static final int DEFAULT_OPERAND_STACK_SIZE = 100;
 
-	public static final Set<String> predefinedAnonSubtemplateAttributes =
-		new HashSet<String>() { { add("i"); add("i0"); } };
+	public static final Set<String> predefinedAnonSubtemplateAttributes;
+
+	static {
+		final Set<String> set = new HashSet<String>();
+		set.add("i");
+		set.add("i0");
+		predefinedAnonSubtemplateAttributes = Collections.unmodifiableSet(set);
+	}
 
 	/** Operand stack, grows upwards. */
 	Object[] operands = new Object[DEFAULT_OPERAND_STACK_SIZE];
@@ -814,7 +820,9 @@ public class Interpreter {
 	}
 
 	protected void map(InstanceScope scope, Object attr, final ST st) {
-		rot_map(scope, attr, new ArrayList<ST>() {{add(st);}});
+		final List<ST> prototypes = new ArrayList<ST>();
+		prototypes.add(st);
+		rot_map(scope, attr, prototypes);
 	}
 
 	/**

--- a/src/org/stringtemplate/v4/compiler/Compiler.java
+++ b/src/org/stringtemplate/v4/compiler/Compiler.java
@@ -27,6 +27,7 @@
  */
 package org.stringtemplate.v4.compiler;
 
+import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.antlr.runtime.ANTLRStringStream;
 import org.antlr.runtime.CommonTokenStream;
@@ -51,40 +52,44 @@ public class Compiler {
 
     public static final int TEMPLATE_INITIAL_CODE_SIZE = 15;
 
-    public static final Map<String, Interpreter.Option> supportedOptions =
-        new HashMap<String, Interpreter.Option>() {
-            {
-                put("anchor",       Interpreter.Option.ANCHOR);
-                put("format",       Interpreter.Option.FORMAT);
-                put("null",         Interpreter.Option.NULL);
-                put("separator",    Interpreter.Option.SEPARATOR);
-                put("wrap",         Interpreter.Option.WRAP);
-            }
-        };
+    public static final Map<String, Interpreter.Option> supportedOptions;
+
+    static {
+	    final Map<String, Interpreter.Option> map = new HashMap<String, Interpreter.Option>();
+	    map.put("anchor",    Interpreter.Option.ANCHOR);
+	    map.put("format",    Interpreter.Option.FORMAT);
+	    map.put("null",      Interpreter.Option.NULL);
+	    map.put("separator", Interpreter.Option.SEPARATOR);
+	    map.put("wrap",      Interpreter.Option.WRAP);
+	    supportedOptions = Collections.unmodifiableMap(map);
+    }
 
     public static final int NUM_OPTIONS = supportedOptions.size();
 
-    public static final Map<String,String> defaultOptionValues =
-        new HashMap<String,String>() {
-            {
-                put("anchor", "true");
-                put("wrap",   "\n");
-            }
-        };
+    public static final Map<String,String> defaultOptionValues;
 
-    public static Map<String, Short> funcs = new HashMap<String, Short>() {
-        {
-            put("first", Bytecode.INSTR_FIRST);
-            put("last", Bytecode.INSTR_LAST);
-            put("rest", Bytecode.INSTR_REST);
-            put("trunc", Bytecode.INSTR_TRUNC);
-            put("strip", Bytecode.INSTR_STRIP);
-            put("trim", Bytecode.INSTR_TRIM);
-            put("length", Bytecode.INSTR_LENGTH);
-            put("strlen", Bytecode.INSTR_STRLEN);
-            put("reverse", Bytecode.INSTR_REVERSE);
-        }
-    };
+    static {
+	    final Map<String, String> map = new HashMap<String, String>();
+	    map.put("anchor", "true");
+	    map.put("wrap",   "\n");
+	    defaultOptionValues = Collections.unmodifiableMap(map);
+    }
+
+    public static Map<String, Short> funcs;
+
+    static {
+	    final Map<String, Short> map = new HashMap<String, Short>();
+	    map.put("first", Bytecode.INSTR_FIRST);
+	    map.put("last", Bytecode.INSTR_LAST);
+	    map.put("rest", Bytecode.INSTR_REST);
+	    map.put("trunc", Bytecode.INSTR_TRUNC);
+	    map.put("strip", Bytecode.INSTR_STRIP);
+	    map.put("trim", Bytecode.INSTR_TRIM);
+	    map.put("length", Bytecode.INSTR_LENGTH);
+	    map.put("strlen", Bytecode.INSTR_STRLEN);
+	    map.put("reverse", Bytecode.INSTR_REVERSE);
+	    funcs = Collections.unmodifiableMap(map);
+    }
 
 	/** Name subtemplates {@code _sub1}, {@code _sub2}, ... */
 	public static AtomicInteger subtemplateCount = new AtomicInteger(0);


### PR DESCRIPTION
[Double-brace initialization](https://stackoverflow.com/questions/1958636/what-is-double-brace-initialization-in-java) is commonly abused for its brevity, but has [performance](https://stackoverflow.com/questions/924285/efficiency-of-java-double-brace-initialization) and clarity implications.

The use of `Collections.unmodifiableSet` and `unmodifiableMap` prevents outsider classes from modifying these collections, which is not desirable.