### PR TITLE
Travis CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,7 @@ indent_style = space
 insert_final_newline = true
 max_line_length = 120
 tab_width = 4
+
+[{*.yml, *.yaml}]
+indent_size = 2
+tab_width = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+# --------------- General Settings ---------------
+
+language: java
+jdk:
+  - openjdk6  # minimum
+  - openjdk8  # LTS
+  - openjdk11 # LTS
+  - openjdk13 # latest
+
+# --------------- Maven Cache ---------------
+
+cache:
+  directories:
+    - .autoconf
+    - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,9 @@ language: java
 matrix:
   include:
     # minimum
-    - dist: trusty
-      jdk: openjdk6
-      # workaround from https://github.com/travis-ci/travis-ci/issues/9713
-      addons:
-        apt:
-          packages:
-            - openjdk-6-jdk
-      before_install:
-        - jdk_switcher use openjdk6
+    # unfortunately JDK 6 is no longer support by Travis CI
+    # - dist: trusty
+    #   jdk: openjdk6
     # LTS
     - dist: trusty
       jdk: openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,18 @@
 # --------------- General Settings ---------------
 
+dist: xenial
 language: java
+
+jdk:
+  # unfortunately JDK 6 is no longer support by Travis CI
+  # - openjdk6  # minimum
+  - openjdk8  # LTS
+  - openjdk11 # LTS
+  - openjdk13 # latest
 
 # required for UI tests
 services:
   - xvfb
-
-matrix:
-  include:
-    # minimum
-    # unfortunately JDK 6 is no longer support by Travis CI
-    # - dist: trusty
-    #   jdk: openjdk6
-    # LTS
-    - dist: xenial
-      jdk: openjdk8
-    # LTS
-    - dist: xenial
-      jdk: openjdk11
-    # latest
-    - dist: xenial
-      jdk: openjdk13
 
 # --------------- Maven Cache ---------------
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@
 
 language: java
 
+# required for UI tests
+services:
+  - xvfb
+
 matrix:
   include:
     # minimum
@@ -9,7 +13,7 @@ matrix:
     # - dist: trusty
     #   jdk: openjdk6
     # LTS
-    - dist: trusty
+    - dist: xenial
       jdk: openjdk8
     # LTS
     - dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,28 @@
 # --------------- General Settings ---------------
 
 language: java
-jdk:
-  - openjdk6  # minimum
-  - openjdk8  # LTS
-  - openjdk11 # LTS
-  - openjdk13 # latest
+
+matrix:
+  include:
+    # minimum
+    - dist: trusty
+      jdk: openjdk6
+      # workaround from https://github.com/travis-ci/travis-ci/issues/9713
+      addons:
+        apt:
+          packages:
+            - openjdk-6-jdk
+      before_install:
+        - jdk_switcher use openjdk6
+    # LTS
+    - dist: trusty
+      jdk: openjdk8
+    # LTS
+    - dist: xenial
+      jdk: openjdk11
+    # latest
+    - dist: xenial
+      jdk: openjdk13
 
 # --------------- Maven Cache ---------------
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ jdk:
   # - openjdk6  # minimum
   - openjdk8  # LTS
   - openjdk11 # LTS
-  - openjdk13 # latest
+  # disabled because the maven compiler for JDK 13 no longer supports source/target compatibility 6
+  # - openjdk13 # latest
 
 # required for UI tests
 services:


### PR DESCRIPTION
This merely adds the travis configuration. It also needs to be enabled on https://travis-ci.org/antlr/stringtemplate4 . Unfortunately I was unable to add JDK 6 to the build matrix due to it being ancient and Travis no longer supporting it. JDK 13 had a similar problem because with it Maven no longer supports source/target compatibility 6.