### PR TITLE
Generify ModelAdaptor

### DIFF
--- a/doc/adaptors.md
+++ b/doc/adaptors.md
@@ -53,7 +53,7 @@ String result = st.render();
 
 |Inheriting from `ObjectModelAdaptor`|
 |---|
-|You can inherit your ModelAdaptor from `ObjectModelAdaptor` to leverage its ability to handle "normal" attributes. You can choose to override the results of any given property or to handle properties that would not normally be handled by the default `ObjectModelAdaptor`.|
+|You can inherit your ModelAdaptor from `ObjectModelAdaptor<T>` to leverage its ability to handle "normal" attributes. You can choose to override the results of any given property or to handle properties that would not normally be handled by the default `ObjectModelAdaptor<T>`.|
 
 ## Example 2
  

--- a/doc/adaptors.md
+++ b/doc/adaptors.md
@@ -1,31 +1,38 @@
 # Model adaptors
 
-StringTemplate lets you access the properties of injected attributes, but only if they follow the JavaBeans naming pattern ("getters") or are publicly visible fields. This works well if you control the attribute class definitions, but falls apart for some models. Some models, though, don't follow the getter method naming convention and so template expressions cannot access properties. To get around this, we need a model adaptor that makes external models look like the kind StringTemplate needs. If object o is of type T, we register a model adaptor object, a, for T that converts property references on o. Given `<o.foo>`, StringTemplate will ask a to get the value of property foo. As with renderers, a is a suitable adaptor if "o is instance of a's associated type". For the statically typed language ports, here are the interfaces:
+StringTemplate lets you access the properties of injected attributes, but only if they follow the JavaBeans naming pattern ("getters") or are publicly visible fields.
+This works well if you control the attribute class definitions, but falls apart for some models.
+Some models, though, don't follow the getter method naming convention and so template expressions cannot access properties.
+To get around this, we need a model adaptor that makes external models look like the kind StringTemplate needs.
+If object `o` is of type `T`, we register a model adaptor object, `a`, for `T` that converts property references on `o`.
+Given `<o.foo>`, StringTemplate will ask `a` to get the value of property `foo`.
+As with renderers, `a` is a suitable adaptor if "`o` is instance of `a`'s associated type".
+For the statically typed language ports, here are the interfaces:
 
 ```java
-public interface ModelAdaptor {
-    public Object getProperty(Interpreter interpreter, ST self, Object o, Object property, String propertyName)
+public interface ModelAdaptor<T> {
+    Object getProperty(Interpreter interpreter, ST self, T model, Object property, String propertyName)
         throws STNoSuchPropertyException;
 }
-``` 
- 
+```
+
 |Property name type|
 |------------------|
-|Property names are usually strings but they don't have to be. For example, if o is a dictionary, the property could be of any key type. The string value of the property name is always passed to the renderer by StringTemplate.|
+|Property names are usually strings but they don't have to be. For example, if `o` is a dictionary, the property could be of any key type. The string value of the property name is always passed to the renderer by StringTemplate.|
 
 ## Example 1
  
 ```java
-class UserAdaptor implements ModelAdaptor {
-    public Object getProperty(Interpreter interpreter, ST self, Object o, Object property, String propertyName)
+class UserAdaptor implements ModelAdaptor<User> {
+    public Object getProperty(Interpreter interpreter, ST self, User model, Object property, String propertyName)
         throws STNoSuchPropertyException
     {
-        if ( propertyName.equals("id") ) return ((User)o).id;
-        if ( propertyName.equals("name") ) return ((User)o).theName();
+        if ( propertyName.equals("id") ) return user.id;
+        if ( propertyName.equals("name") ) return user.theName();
         throw new STNoSuchPropertyException(null, "User."+propertyName);
     }
 }
- 
+
 public static class User {
     private int id; // ST can't see; it's private
     private String name;
@@ -44,9 +51,9 @@ String expecting = "100: parrt";
 String result = st.render();
 ```
 
-|Inheriting from ObjectModelAdaptor|
+|Inheriting from `ObjectModelAdaptor`|
 |---|
-|You can inherit your ModelAdaptor from ObjectModelAdaptor to leverage its ability to handle "normal" attributes. You can choose to override the results of any given property or to handle properties that would not normally be handled by the default ObjectModelAdaptor.|
+|You can inherit your ModelAdaptor from `ObjectModelAdaptor` to leverage its ability to handle "normal" attributes. You can choose to override the results of any given property or to handle properties that would not normally be handled by the default `ObjectModelAdaptor`.|
 
 ## Example 2
  
@@ -63,7 +70,7 @@ class UserAdaptor extends ObjectModelAdaptor {
         return super.getProperty(interpreter,self,o,property,propertyName);
     }
 }
- 
+
 public static class User {
     public int id; // ST can see this and we'll let ObjectModelAdaptor handle it
     public String name;  // ST can see this, but we'll override to capitalize

--- a/doc/adaptors.md
+++ b/doc/adaptors.md
@@ -27,8 +27,8 @@ class UserAdaptor implements ModelAdaptor<User> {
     public Object getProperty(Interpreter interpreter, ST self, User model, Object property, String propertyName)
         throws STNoSuchPropertyException
     {
-        if ( propertyName.equals("id") ) return user.id;
-        if ( propertyName.equals("name") ) return user.theName();
+        if ( propertyName.equals("id") ) return model.id;
+        if ( propertyName.equals("name") ) return model.theName();
         throw new STNoSuchPropertyException(null, "User."+propertyName);
     }
 }
@@ -58,16 +58,16 @@ String result = st.render();
 ## Example 2
  
 ```java
-class UserAdaptor extends ObjectModelAdaptor {
-    public Object getProperty(Interpreter interpreter, ST self, Object o, Object property, String propertyName)
+class UserAdaptor extends ObjectModelAdaptor<User> {
+    public Object getProperty(Interpreter interpreter, ST self, User model, Object property, String propertyName)
         throws STNoSuchPropertyException
     {
         // intercept handling of "name" property and capitalize first character
-        if ( propertyName.equals("name") ) return ((User)o).name.substring(0,1).toUpperCase()+((User)o).name.substring(1);
+        if ( propertyName.equals("name") ) return model.name.substring(0,1).toUpperCase()+model.name.substring(1);
         // respond to "description" property by composing desired result
-        if ( propertyName.equals("description") ) return "User object with id:" + ((User)o).id;
+        if ( propertyName.equals("description") ) return "User object with id:" + model.id;
         // let "id" be handled by ObjectModelAdaptor
-        return super.getProperty(interpreter,self,o,property,propertyName);
+        return super.getProperty(interpreter,self,model,property,propertyName);
     }
 }
 

--- a/src/org/stringtemplate/v4/ModelAdaptor.java
+++ b/src/org/stringtemplate/v4/ModelAdaptor.java
@@ -43,8 +43,11 @@ import java.util.Map;
  * <p>
  * Given {@code <a.foo>}, we look up {@code foo} via the adaptor if
  * {@code a instanceof M}.</p>
+ *
+ * @param <T>
+ *     the type of values this adaptor can handle.
  */
-public interface ModelAdaptor {
+public interface ModelAdaptor<T> {
     /**
      * Lookup property name in {@code o} and return its value.
      * <p>
@@ -53,6 +56,6 @@ public interface ModelAdaptor {
      * any key type. If we need to convert to {@code String}, then it's done by
      * {@code ST} and passed in here.</p>
      */
-    Object getProperty(Interpreter interp, ST self, Object o, Object property, String propertyName)
+    Object getProperty(Interpreter interp, ST self, T model, Object property, String propertyName)
         throws STNoSuchPropertyException;
 }

--- a/src/org/stringtemplate/v4/STGroup.java
+++ b/src/org/stringtemplate/v4/STGroup.java
@@ -158,9 +158,9 @@ public class STGroup {
      * <p>
      *  The last one you register gets priority; do least to most specific.</p>
      */
-    protected final Map<Class<?>, ModelAdaptor> adaptors;
+    protected final Map<Class<?>, ModelAdaptor<?>> adaptors;
     {
-        TypeRegistry<ModelAdaptor> registry = new TypeRegistry<ModelAdaptor>();
+        TypeRegistry<ModelAdaptor<?>> registry = new TypeRegistry<ModelAdaptor<?>>();
         registry.put(Object.class, new ObjectModelAdaptor());
         registry.put(ST.class, new STModelAdaptor());
         registry.put(Map.class, new MapModelAdaptor());
@@ -736,7 +736,7 @@ public class STGroup {
      * This must invalidate cache entries, so set your adaptors up before
      * calling {@link ST#render} for efficiency.</p>
      */
-    public void registerModelAdaptor(Class<?> attributeType, ModelAdaptor adaptor) {
+    public <T> void registerModelAdaptor(Class<T> attributeType, ModelAdaptor<? super T> adaptor) {
         if ( attributeType.isPrimitive() ) {
             throw new IllegalArgumentException("can't register ModelAdaptor for primitive type "+
                                                attributeType.getSimpleName());
@@ -745,8 +745,9 @@ public class STGroup {
         adaptors.put(attributeType, adaptor);
     }
 
-    public ModelAdaptor getModelAdaptor(Class<?> attributeType) {
-        return adaptors.get(attributeType);
+    public <T> ModelAdaptor<T> getModelAdaptor(Class<? extends T> attributeType) {
+        //noinspection unchecked
+        return (ModelAdaptor<T>) adaptors.get(attributeType);
     }
 
     /** Register a renderer for all objects of a particular "kind" for all

--- a/src/org/stringtemplate/v4/STGroup.java
+++ b/src/org/stringtemplate/v4/STGroup.java
@@ -161,7 +161,7 @@ public class STGroup {
     protected final Map<Class<?>, ModelAdaptor<?>> adaptors;
     {
         TypeRegistry<ModelAdaptor<?>> registry = new TypeRegistry<ModelAdaptor<?>>();
-        registry.put(Object.class, new ObjectModelAdaptor());
+        registry.put(Object.class, new ObjectModelAdaptor<Object>());
         registry.put(ST.class, new STModelAdaptor());
         registry.put(Map.class, new MapModelAdaptor());
         registry.put(Aggregate.class, new AggregateModelAdaptor());

--- a/src/org/stringtemplate/v4/STGroup.java
+++ b/src/org/stringtemplate/v4/STGroup.java
@@ -747,7 +747,7 @@ public class STGroup {
 
     public <T> ModelAdaptor<? super T> getModelAdaptor(Class<T> attributeType) {
         //noinspection unchecked
-        return (ModelAdaptor<T>) adaptors.get(attributeType);
+        return (ModelAdaptor<? super T>) adaptors.get(attributeType);
     }
 
     /** Register a renderer for all objects of a particular "kind" for all

--- a/src/org/stringtemplate/v4/misc/AggregateModelAdaptor.java
+++ b/src/org/stringtemplate/v4/misc/AggregateModelAdaptor.java
@@ -29,17 +29,17 @@
 package org.stringtemplate.v4.misc;
 
 import org.stringtemplate.v4.Interpreter;
+import org.stringtemplate.v4.ModelAdaptor;
 import org.stringtemplate.v4.ST;
 
-import java.util.Map;
-
 /** Deal with structs created via {@link ST#addAggr}{@code ("structname.{prop1, prop2}", ...);}. */
-public class AggregateModelAdaptor extends MapModelAdaptor {
+public class AggregateModelAdaptor implements ModelAdaptor<Aggregate> {
+    private final MapModelAdaptor mapAdaptor = new MapModelAdaptor();
+
     @Override
-    public Object getProperty(Interpreter interp, ST self, Object o, Object property, String propertyName)
+    public Object getProperty(Interpreter interp, ST self, Aggregate o, Object property, String propertyName)
         throws STNoSuchPropertyException
     {
-        Map<?, ?> map = ((Aggregate)o).properties;
-        return super.getProperty(interp, self, map, property, propertyName);
+        return mapAdaptor.getProperty(interp, self, o.properties, property, propertyName);
     }
 }

--- a/src/org/stringtemplate/v4/misc/MapModelAdaptor.java
+++ b/src/org/stringtemplate/v4/misc/MapModelAdaptor.java
@@ -34,21 +34,20 @@ import org.stringtemplate.v4.STGroup;
 
 import java.util.Map;
 
-public class MapModelAdaptor implements ModelAdaptor {
+public class MapModelAdaptor implements ModelAdaptor<Map<?, ?>> {
     @Override
-    public Object getProperty(Interpreter interp, ST self, Object o, Object property, String propertyName)
+    public Object getProperty(Interpreter interp, ST self, Map<?, ?> model, Object property, String propertyName)
         throws STNoSuchPropertyException
     {
         Object value;
-        Map<?, ?> map = (Map<?, ?>)o;
-        if ( property==null ) value = getDefaultValue(map);
-        else if ( containsKey(map, property) ) value = map.get(property);
-        else if ( containsKey(map, propertyName) ) { // if can't find the key, try toString version
-            value = map.get(propertyName);
+        if ( property==null ) value = getDefaultValue(model);
+        else if ( containsKey(model, property) ) value = model.get(property);
+        else if ( containsKey(model, propertyName) ) { // if can't find the key, try toString version
+            value = model.get(propertyName);
         }
-        else if ( property.equals("keys") ) value = map.keySet();
-        else if ( property.equals("values") ) value = map.values();
-        else value = getDefaultValue(map); // not found, use default
+        else if ( property.equals("keys") ) value = model.keySet();
+        else if ( property.equals("values") ) value = model.values();
+        else value = getDefaultValue(model); // not found, use default
         if ( value == STGroup.DICT_KEY ) {
             value = property;
         }

--- a/src/org/stringtemplate/v4/misc/ObjectModelAdaptor.java
+++ b/src/org/stringtemplate/v4/misc/ObjectModelAdaptor.java
@@ -37,7 +37,7 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
-public class ObjectModelAdaptor implements ModelAdaptor<Object> {
+public class ObjectModelAdaptor<T> implements ModelAdaptor<T> {
     protected static final Member INVALID_MEMBER;
     static {
         Member invalidMember;
@@ -56,14 +56,14 @@ public class ObjectModelAdaptor implements ModelAdaptor<Object> {
         new HashMap<Class<?>, Map<String, Member>>();
 
     @Override
-    public synchronized Object getProperty(Interpreter interp, ST self, Object o, Object property, String propertyName)
+    public synchronized Object getProperty(Interpreter interp, ST self, T model, Object property, String propertyName)
         throws STNoSuchPropertyException
     {
-        if (o == null) {
+        if (model == null) {
             throw new NullPointerException("o");
         }
 
-        Class<?> c = o.getClass();
+        Class<?> c = model.getClass();
 
         if ( property==null ) {
             return throwNoSuchProperty(c, propertyName, null);
@@ -73,10 +73,10 @@ public class ObjectModelAdaptor implements ModelAdaptor<Object> {
         if ( member!=null ) {
             try {
                 if (member instanceof Method) {
-                    return ((Method)member).invoke(o);
+                    return ((Method)member).invoke(model);
                 }
                 else if (member instanceof Field) {
-                    return ((Field)member).get(o);
+                    return ((Field)member).get(model);
                 }
             }
             catch (Exception e) {

--- a/src/org/stringtemplate/v4/misc/ObjectModelAdaptor.java
+++ b/src/org/stringtemplate/v4/misc/ObjectModelAdaptor.java
@@ -37,7 +37,7 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
-public class ObjectModelAdaptor implements ModelAdaptor {
+public class ObjectModelAdaptor implements ModelAdaptor<Object> {
     protected static final Member INVALID_MEMBER;
     static {
         Member invalidMember;

--- a/src/org/stringtemplate/v4/misc/STModelAdaptor.java
+++ b/src/org/stringtemplate/v4/misc/STModelAdaptor.java
@@ -31,12 +31,11 @@ import org.stringtemplate.v4.Interpreter;
 import org.stringtemplate.v4.ModelAdaptor;
 import org.stringtemplate.v4.ST;
 
-public class STModelAdaptor implements ModelAdaptor {
+public class STModelAdaptor implements ModelAdaptor<ST> {
     @Override
-    public Object getProperty(Interpreter interp, ST self, Object o, Object property, String propertyName)
+    public Object getProperty(Interpreter interp, ST self, ST model, Object property, String propertyName)
         throws STNoSuchPropertyException
     {
-        ST st = (ST)o;
-        return st.getAttribute(propertyName);
+        return model.getAttribute(propertyName);
     }
 }

--- a/test/org/stringtemplate/v4/test/TestModelAdaptors.java
+++ b/test/org/stringtemplate/v4/test/TestModelAdaptors.java
@@ -11,25 +11,25 @@ import static org.junit.Assert.assertEquals;
 import java.util.TreeMap;
 
 public class TestModelAdaptors extends BaseTest {
-    static class UserAdaptor implements ModelAdaptor {
+    static class UserAdaptor implements ModelAdaptor<User> {
         @Override
-        public Object getProperty(Interpreter interp, ST self, Object o, Object property, String propertyName)
+        public Object getProperty(Interpreter interp, ST self, User model, Object property, String propertyName)
             throws STNoSuchPropertyException
         {
-            if ( propertyName.equals("id") ) return ((User)o).id;
-            if ( propertyName.equals("name") ) return ((User)o).getName();
-            throw new STNoSuchPropertyException(null, o, "User."+propertyName);
+            if ( propertyName.equals("id") ) return model.id;
+            if ( propertyName.equals("name") ) return model.getName();
+            throw new STNoSuchPropertyException(null, model, "User."+propertyName);
         }
     }
 
-    static class UserAdaptorConst implements ModelAdaptor {
+    static class UserAdaptorConst implements ModelAdaptor<User> {
         @Override
-        public Object getProperty(Interpreter interp, ST self, Object o, Object property, String propertyName)
+        public Object getProperty(Interpreter interp, ST self, User model, Object property, String propertyName)
             throws STNoSuchPropertyException
         {
             if ( propertyName.equals("id") ) return "const id value";
             if ( propertyName.equals("name") ) return "const name value";
-            throw new STNoSuchPropertyException(null, o, "User."+propertyName);
+            throw new STNoSuchPropertyException(null, model, "User."+propertyName);
         }
     }
 


### PR DESCRIPTION
As suggested in #233

The only change introduced by this that can be considered breaking is the removal of the superclass `MapModelAdaptor` from `AggregateModelAdaptor`. The inheritance was replaced by composition. This had to be done because `MapModelAdaptor` is now a `ModelAdaptor<Map>`, while `AggregateModelAdaptor` needs to be a `ModelAdaptor<Aggregate>`. Previously, `AggregateModelAdaptor` could not handle a Map, so I think this "breaking" change should not cause any issues.