### PR TITLE
Fix signature of STGroup.getAttributeRenderer

### DIFF
--- a/src/org/stringtemplate/v4/Interpreter.java
+++ b/src/org/stringtemplate/v4/Interpreter.java
@@ -792,7 +792,7 @@ public class Interpreter {
     protected int writePOJO(STWriter out, InstanceScope scope, Object o, String[] options) throws IOException {
         String formatString = null;
         if ( options!=null ) formatString = options[Option.FORMAT.ordinal()];
-        String v = renderObject(scope, formatString, o);
+        String v = renderObject(scope, formatString, o, o.getClass());
         int n;
         if ( options!=null && options[Option.WRAP.ordinal()]!=null ) {
             n = out.write(v, options[Option.WRAP.ordinal()]);

--- a/src/org/stringtemplate/v4/Interpreter.java
+++ b/src/org/stringtemplate/v4/Interpreter.java
@@ -792,7 +792,7 @@ public class Interpreter {
     protected int writePOJO(STWriter out, InstanceScope scope, Object o, String[] options) throws IOException {
         String formatString = null;
         if ( options!=null ) formatString = options[Option.FORMAT.ordinal()];
-        String v = renderObject(scope, formatString, o, o.getClass());
+        String v = renderObject(scope, formatString, o);
         int n;
         if ( options!=null && options[Option.WRAP.ordinal()]!=null ) {
             n = out.write(v, options[Option.WRAP.ordinal()]);
@@ -803,9 +803,10 @@ public class Interpreter {
         return n;
     }
 
-    private <T> String renderObject(InstanceScope scope, String formatString, T o, Class<? extends T> attributeType) {
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    private String renderObject(InstanceScope scope, String formatString, Object o) {
         // ask the native group defining the surrounding template for the renderer
-        AttributeRenderer<? super T> r = scope.st.impl.nativeGroup.getAttributeRenderer(attributeType);
+        AttributeRenderer r = scope.st.impl.nativeGroup.getAttributeRenderer(o.getClass());
         if ( r!=null ) {
             return r.toString(o, formatString, locale);
         } else {

--- a/src/org/stringtemplate/v4/Interpreter.java
+++ b/src/org/stringtemplate/v4/Interpreter.java
@@ -803,10 +803,9 @@ public class Interpreter {
         return n;
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
     private <T> String renderObject(InstanceScope scope, String formatString, Object o, Class<T> attributeType) {
         // ask the native group defining the surrounding template for the renderer
-        AttributeRenderer<? super T> r = scope.st.impl.nativeGroup.getAttributeRenderer(o);
+        AttributeRenderer<? super T> r = scope.st.impl.nativeGroup.getAttributeRenderer(attributeType);
         if ( r!=null ) {
             return r.toString(attributeType.cast(o), formatString, locale);
         } else {

--- a/src/org/stringtemplate/v4/Interpreter.java
+++ b/src/org/stringtemplate/v4/Interpreter.java
@@ -804,11 +804,11 @@ public class Interpreter {
     }
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
-    private String renderObject(InstanceScope scope, String formatString, Object o) {
+    private <T> String renderObject(InstanceScope scope, String formatString, Object o, Class<T> attributeType) {
         // ask the native group defining the surrounding template for the renderer
-        AttributeRenderer r = scope.st.impl.nativeGroup.getAttributeRenderer(o.getClass());
+        AttributeRenderer<? super T> r = scope.st.impl.nativeGroup.getAttributeRenderer(o);
         if ( r!=null ) {
-            return r.toString(o, formatString, locale);
+            return r.toString(attributeType.cast(o), formatString, locale);
         } else {
             return o.toString();
         }
@@ -1450,4 +1450,3 @@ public class Interpreter {
     }
 
 }
-

--- a/src/org/stringtemplate/v4/STGroup.java
+++ b/src/org/stringtemplate/v4/STGroup.java
@@ -789,7 +789,7 @@ public class STGroup {
      *  have multiple renderers for {@code String}, say, then just make uber combined
      *  renderer with more specific format names.</p>
      */
-    public <T> AttributeRenderer<? super T> getAttributeRenderer(Class<? extends T> attributeType) {
+    public <T> AttributeRenderer<? super T> getAttributeRenderer(Class<T> attributeType) {
         if ( renderers==null ) {
             return null;
         }


### PR DESCRIPTION
This amends #233 with a minor change to the signature of `STGroup#getAttributeRenderer`, as [requested](https://github.com/antlr/stringtemplate4/pull/235#discussion_r362019387) by @sharwell.