### PR TITLE
Fix backward compatibility issues introduced by #233

### DIFF
--- a/src/org/stringtemplate/v4/NumberRenderer.java
+++ b/src/org/stringtemplate/v4/NumberRenderer.java
@@ -39,10 +39,9 @@ import java.util.Locale;
  *  For example, {@code %10d} emits a number as a decimal int padding to 10 char.
  *  This can even do {@code long} to {@code Date} conversions using the format string.</p>
  */
-public class NumberRenderer implements AttributeRenderer<Number> {
+public class NumberRenderer implements AttributeRenderer<Object> {
     @Override
-    public String toString(Number value, String formatString, Locale locale) {
-        // value will be instanceof Number
+    public String toString(Object value, String formatString, Locale locale) {
         if ( formatString==null ) return value.toString();
         Formatter f = new Formatter(locale);
         try {

--- a/src/org/stringtemplate/v4/StringRenderer.java
+++ b/src/org/stringtemplate/v4/StringRenderer.java
@@ -40,9 +40,16 @@ import java.util.Locale;
  *  <li>{@code xml-encode}:</li>
  * </ul>
  */
-public class StringRenderer implements AttributeRenderer<String> {
-    // trim(s) and strlen(s) built-in funcs; these are format options
+public class StringRenderer implements AttributeRenderer<Object> {
+    // accepts Object for backward compatibility,
+    // but fails when value is not a String at runtime
+
     @Override
+    public String toString(Object value, String formatString, Locale locale) {
+        return toString((String) value, formatString, locale);
+    }
+
+    // trim(s) and strlen(s) built-in funcs; these are format options
     public String toString(String value, String formatString, Locale locale) {
         if ( formatString==null ) return value;
         if ( formatString.equals("upper") ) return value.toUpperCase(locale);


### PR DESCRIPTION
Reverts NumberRenderer and StringRenderer to accept Object instead of Number or String respectively.

NumberRenderer always worked with Object before.
Actually it should be called FormatRenderer or similar because it merely uses Formatter, nothing Number-specific.

StringRenderer now uses the pre-#233 behaviour of accepting Object at runtime, but failing if the actual value is not a String due to the forced cast.

The main motivation is that #233 broke code like this:

```java
class CustomStringRenderer extends StringRenderer {
    @Override
    public String toString(Object value, String formatString, Locale locale) {
        if ("decap".equals(formatString)) { return ... };
        return super.toString(value, formatString, locale);
    }
}
```

Now suddenly that method no longer overrides `toString` from `StringRenderer`, because it had the signature `toString(`**`String`**`, String, Locale)` in #233. And now we have breaking changes!

See https://github.com/Clashsoft/GenTreeSrc/blob/master/src/main/java/de/clashsoft/gentreesrc/codegen/StringRenderer.java for an example of this in the wild.