### PR TITLE
Re-enable Revapi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <oldVersion>4.3</oldVersion>
                     <analysisConfigurationFiles>
                         <configurationFile>
                             <path>revapi.json</path>

--- a/pom.xml
+++ b/pom.xml
@@ -113,12 +113,13 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <oldVersion>4.3</oldVersion>
+                    <oldVersion>4.1</oldVersion>
                     <analysisConfigurationFiles>
                         <configurationFile>
                             <path>revapi.json</path>
                             <roots>
                                 <root>base</root>
+                                <root>4.2+</root>
                                 <root>4.3+</root>
                             </roots>
                         </configurationFile>

--- a/pom.xml
+++ b/pom.xml
@@ -94,12 +94,13 @@
 					</execution>
 				</executions>
 			</plugin>
-            <!--
             <plugin>
+                <!-- https://mvnrepository.com/artifact/org.revapi/revapi-maven-plugin -->
                 <groupId>org.revapi</groupId>
                 <artifactId>revapi-maven-plugin</artifactId>
                 <version>0.11.2</version>
                 <dependencies>
+                    <!-- https://mvnrepository.com/artifact/org.revapi/revapi-java -->
                     <dependency>
                         <groupId>org.revapi</groupId>
                         <artifactId>revapi-java</artifactId>
@@ -123,7 +124,6 @@
                     </analysisConfigurationFiles>
                 </configuration>
             </plugin>
-            -->
         </plugins>
 	</build>
 

--- a/revapi.json
+++ b/revapi.json
@@ -1,4 +1,28 @@
 {
+  "base": {
+    "revapi": {
+      "ignore": [
+        {
+          "code": "java.field.constantValueChanged",
+          "old": "field org.stringtemplate.v4.ST.VERSION",
+          "new": "field org.stringtemplate.v4.ST.VERSION",
+          "justification": "this constant changes with every release because it indicates the current version"
+        }
+      ]
+    }
+  },
+  "4.2+": {
+    "revapi": {
+      "ignore": [
+        {
+          "code": "java.field.typeChanged",
+          "old": "field org.stringtemplate.v4.compiler.Compiler.subtemplateCount",
+          "new": "field org.stringtemplate.v4.compiler.Compiler.subtemplateCount",
+          "justification": "https://github.com/antlr/stringtemplate4/pull/220"
+        }
+      ]
+    }
+  },
   "4.3+": {
     "revapi": {
       "ignore": [


### PR DESCRIPTION
Re-enables the Revapi Maven plugin.

I tried to fix the problem that it breaks when releasing a new version by explicitly setting the `oldVersion` it should compare against.


~I believe all that needs to be done next time is update this to the version number of the newly released version. E.g., *after* releasing v4.4, change `<oldVersion>4.3</oldVersion>` to `<oldVersion>4.4</oldVersion>` in a new commit. The important part is the new version needs to be available on Maven by the time this commit is made.~

Update: don't have to do anything any more.