### PR TITLE
Parameterize `NumberRenderer` to `Number`.

### DIFF
--- a/src/org/stringtemplate/v4/NumberRenderer.java
+++ b/src/org/stringtemplate/v4/NumberRenderer.java
@@ -39,9 +39,9 @@ import java.util.Locale;
  *  For example, {@code %10d} emits a number as a decimal int padding to 10 char.
  *  This can even do {@code long} to {@code Date} conversions using the format string.</p>
  */
-public class NumberRenderer implements AttributeRenderer<Object> {
+public class NumberRenderer implements AttributeRenderer<Number> {
     @Override
-    public String toString(Object value, String formatString, Locale locale) {
+    public String toString(Number value, String formatString, Locale locale) {
         if ( formatString==null ) return value.toString();
         Formatter f = new Formatter(locale);
         try {


### PR DESCRIPTION
Now that `AttributeRenderer` is generic, `NumberRenderer` should be parameterized for `Number` rather than `Object`.