### PR TITLE
Ignore all Exceptions during method and field lookup in ObjectModelAdaptor

### DIFF
--- a/src/org/stringtemplate/v4/misc/ObjectModelAdaptor.java
+++ b/src/org/stringtemplate/v4/misc/ObjectModelAdaptor.java
@@ -139,8 +139,7 @@ public class ObjectModelAdaptor<T> implements ModelAdaptor<T> {
             }
 
             return method;
-        } catch (NoSuchMethodException ex) {
-        } catch (SecurityException ex) {
+        } catch (Exception ex) {
         }
 
         return null;
@@ -154,8 +153,7 @@ public class ObjectModelAdaptor<T> implements ModelAdaptor<T> {
             }
 
             return field;
-        } catch (NoSuchFieldException ex) {
-        } catch (SecurityException ex) {
+        } catch (Exception ex) {
         }
 
         return null;


### PR DESCRIPTION
This addresses #249, and is consistent with `getProperty` in that it converts any Exception to a `STNoSuchPropertyException`.

Closes #249 