### PR TITLE
Updating scala documentation to be more idiomatic and work with ST4

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -61,3 +61,7 @@ YYYY/MM/DD, github id, Full name, email
 2019/09/09, seanabraham, Sean Abraham, Sean.A208@gmail.com
 2019/12/22, Clashsoft, Adrian Kunz, clashsoft at hotmail dot com
 2020/04/21, steinybot, Jason Pickens, jasonpickensnz@gmail.com
+2020/07/23, mma-tapad, Marvin Ma, marvin.ma@tapad.com
+2020/07/23, zjzsliyang, Yang Li, zjzsliyang@gmail.com
+2020/07/23, jamesmahler2, James Mahler, jmahler@andrew.cmu.edu
+2020/07/23, dyuan0226, David Yuan, dyuan1@andrew.cmu.edu

--- a/doc/faq/index.md
+++ b/doc/faq/index.md
@@ -10,5 +10,5 @@ This is the main landing page for the StringTemplate 4 FAQ. The links below will
 
 ## Object models
 
-* [Altering property lookup for Scala](object-models.md)
+* [Altering property lookup for Scala](../scala-model-adaptor.md)
 

--- a/doc/scala-model-adaptor.md
+++ b/doc/scala-model-adaptor.md
@@ -24,7 +24,6 @@ trait ToJava {
   /**
     * Recursively converts to java object that is usable by ST4
     * Note: For Options, None is converted to empty string ("")
-    * @see library docs at: [[https://github.com/antlr/stringtemplate4/blob/master/doc/faq/object-models.md]]
     */
   def toObject(o: Any): Object = {
     o match {


### PR DESCRIPTION
The existing scala adaptor documentation is written in a Java-like way and not the way typical Scala would be written. Additionally, the ST calls it uses have been refactored/deprecated. This PR updates the documentation.

We would also like to change the filename (and references to this file) from `object-models.md` to something more descriptive like `scala-model-adaptor.md`. We'll make the appropriate commits if we get the OK.

Co-authored-by: James Mahler <jmahler@andrew.cmu.edu>
Co-authored-by: Yang LI <zjzsliyang@gmail.com>
Co-authored-by: dyuan0226 <dyuan1@andrew.cmu.edu>