### PR TITLE
Correctly handle surrogate pairs in StringRenderer.encodeHTML

### DIFF
--- a/src/org/stringtemplate/v4/StringRenderer.java
+++ b/src/org/stringtemplate/v4/StringRenderer.java
@@ -76,8 +76,8 @@ public class StringRenderer implements AttributeRenderer<Object> {
         }
         StringBuilder buf = new StringBuilder( s.length() );
         int len = s.length();
-        for (int i=0; i<len; i++) {
-            char c = s.charAt(i);
+        for (int i=0; i<len;) {
+            int c = s.codePointAt(i);
             switch ( c ) {
                 case '&' :
                     buf.append("&amp;");
@@ -98,11 +98,14 @@ public class StringRenderer implements AttributeRenderer<Object> {
                     boolean aboveASCII = c > 126;
                     if ( control || aboveASCII ) {
                         buf.append("&#");
-                        buf.append((int)c);
+                        buf.append(c);
                         buf.append(";");
                     }
-                    else buf.append(c);
+                    else {
+                        buf.append((char)c);
+                    }
             }
+            i += Character.charCount(c);
         }
         return buf.toString();
     }

--- a/src/org/stringtemplate/v4/StringRenderer.java
+++ b/src/org/stringtemplate/v4/StringRenderer.java
@@ -91,7 +91,7 @@ public class StringRenderer implements AttributeRenderer<Object> {
                 case '\r':
                 case '\n':
                 case '\t':
-                    buf.append(c);
+                    buf.append((char)c);
                     break;
                 default:
                     boolean control = c < ' '; // 32

--- a/test/org/stringtemplate/v4/test/TestRenderers.java
+++ b/test/org/stringtemplate/v4/test/TestRenderers.java
@@ -265,6 +265,20 @@ public class TestRenderers extends BaseTest {
         assertEquals(expecting, result);
     }
 
+    @Test public void testStringRendererWithFormat_xml_encode_emoji() throws Exception {
+        String templates =
+            "foo(x) ::= << <x; format=\"xml-encode\"> >>\n";
+
+        writeFile(tmpdir, "t.stg", templates);
+        STGroup group = new STGroupFile(tmpdir+"/t.stg");
+        group.registerRenderer(String.class, new StringRenderer());
+        ST st = group.getInstanceOf("foo");
+        st.add("x", "\uD83E\uDE73");
+        String expecting = " &#129651; ";
+        String result = st.render();
+        assertEquals(expecting, result);
+    }
+
     @Test public void testStringRendererWithPrintfFormat() throws Exception {
         String templates =
                 "foo(x) ::= << <x; format=\"%6s\"> >>\n";


### PR DESCRIPTION
Changed the `StringRenderer.encodeHTML` method, i.e. the implementation for `format="xml-encode"`, in order to support Unicode characters encoded as two `char`s (surrogate pairs). An example where this problem occurred was with emojis, as outlined in #260. While the old implementation produced two invalid HTML entities `&#55358;&#56947;` for the two characters encoding the emoji "🩳", after this change it only generates one entity, namely `&#129651;` (ref.: https://unicode-table.com/de/1FA73/)

Closes #260 