### PR TITLE
Fix escaping for closing angle brackets.

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -65,3 +65,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/07/23, zjzsliyang, Yang Li, zjzsliyang@gmail.com
 2020/07/23, jamesmahler2, James Mahler, jmahler@andrew.cmu.edu
 2020/07/23, dyuan0226, David Yuan, dyuan1@andrew.cmu.edu
+2020/09/06, peteruhnak, Peter Uhnak, i.uhnak@gmail.com

--- a/src/org/stringtemplate/v4/misc/Misc.java
+++ b/src/org/stringtemplate/v4/misc/Misc.java
@@ -132,29 +132,33 @@ public class Misc {
         return s;
     }
 
-    /** Replace &gt;\&gt; with &gt;&gt; in s. Replace \&gt;&gt; unless prefix of \&gt;&gt;&gt; with &gt;&gt;.
-     *  Do NOT replace if it's &lt;\\&gt;
+    /**
+     * Replace &gt;\&gt; with &gt;&gt; in s.
+     * <p>
+     * Replace \&gt; with &gt; in s, unless prefix of \&gt;&gt;&gt;.
+     * <p>
+     * Do NOT replace if it's &lt;\\&gt;
      */
     public static String replaceEscapedRightAngle(String s) {
         StringBuilder buf = new StringBuilder();
         int i = 0;
         while ( i<s.length() ) {
             char c = s.charAt(i);
-            if ( c=='<' && s.substring(i).startsWith("<\\\\>") ) {
+            if ( c=='<' && s.startsWith("<\\\\>", i) ) {
                 buf.append("<\\\\>");
                 i += "<\\\\>".length();
                 continue;
             }
-            if ( c=='>' && s.substring(i).startsWith(">\\>") ) {
+            if ( c=='>' && s.startsWith(">\\>", i) ) {
                 buf.append(">>");
                 i += ">\\>".length();
                 continue;
             }
-            if ( c=='\\' && s.substring(i).startsWith("\\>>") &&
-                !s.substring(i).startsWith("\\>>>") )
+            if ( c=='\\' && s.startsWith("\\>", i) &&
+                !s.startsWith("\\>>>", i) )
             {
-                buf.append(">>");
-                i += "\\>>".length();
+                buf.append(">");
+                i += "\\>".length();
                 continue;
             }
             buf.append(c);

--- a/test/org/stringtemplate/v4/test/TestGroups.java
+++ b/test/org/stringtemplate/v4/test/TestGroups.java
@@ -73,6 +73,17 @@ public class TestGroups extends BaseTest {
         assertEquals(expected, result);
     }
 
+    @Test public void testEscapeOneRightAngle2() throws Exception {
+        String dir = getRandomDir();
+        writeFile(dir, "a.st", "a(x) ::= << \\> >>");
+        STGroup group = new STGroupDir(dir);
+        ST st = group.getInstanceOf("a");
+        st.add("x", "parrt");
+        String expected = " > ";
+        String result = st.render();
+        assertEquals(expected, result);
+    }
+
     @Test public void testEscapeJavaRightShift() throws Exception {
         String dir = getRandomDir();
         writeFile(dir, "a.st", "a(x) ::= << \\>> >>");


### PR DESCRIPTION
This reintroduces closing angle bracket escaping as discussed in https://github.com/antlr/stringtemplate4/issues/198 .

Note that this applies only to `STGroup`, not `ST` -- same way it was in 4.0.4 and prior.