### PR TITLE
Fix for NPE when Thread.currentThread().getContextClassLoader() is null.

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -67,3 +67,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/07/23, dyuan0226, David Yuan, dyuan1@andrew.cmu.edu
 2020/09/06, peteruhnak, Peter Uhnak, i.uhnak@gmail.com
 2020/09/16, Dvoreth, Jarmila Emanuela Panwitz, jaremapan@gmail.com
+2020/10/01, beccagaspard, Becca Gaspard, beccagaspard at gmail dot com

--- a/src/org/stringtemplate/v4/STGroup.java
+++ b/src/org/stringtemplate/v4/STGroup.java
@@ -837,12 +837,12 @@ public class STGroup {
     public URL getRootDirURL() { return null; }
 
     public URL getURL(String fileName) {
-        URL url;
+        URL url = null;
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
-        url = cl.getResource(fileName);
+        if ( cl!=null ) url = cl.getResource(fileName);
         if ( url==null ) {
             cl = this.getClass().getClassLoader();
-            url = cl.getResource(fileName);
+            if ( cl!=null ) url = cl.getResource(fileName);
         }
         return url;
     }


### PR DESCRIPTION
Fix for NPE in `STGroup::getUrl` when `Thread.currentThread().getContextClassLoader()` is null.  We experienced this issue with version 4.0.8 in an OSGI environment where `Thread.currentThread().getContextClassLoader()` was null but `this.getClass().getClassLoader()` was populated and would have been able to resolve the `fileName` if a NPE had not been thrown.  Added null check for both classloaders.  I tried to follow your existing code formatting, please let me know if any changes are needed! 🤓 

Stacktrace: 
```
can't load group file jar:file:/usr/local/tomcat/webapps/ROOT/WEB-INF/lib/killbill-invoice-0.22.10.jar!/org/killbill/billing/invoice/dao/InvoiceSqlDao.sql.stg
Caused by: java.lang.NullPointerException
    at org.stringtemplate.v4.STGroup.getURL(STGroup.java:774)
    at org.stringtemplate.v4.STGroupFile.<init>(STGroupFile.java:67)
    at org.stringtemplate.v4.STGroup.importTemplates(STGroup.java:563)
    at org.stringtemplate.v4.compiler.GroupParser.group(GroupParser.java:199)
    at org.stringtemplate.v4.STGroup.loadGroupFile(STGroup.java:612)
    at org.stringtemplate.v4.STGroupFile.load(STGroupFile.java:139)
    at org.stringtemplate.v4.STGroupFile.load(STGroupFile.java:128)
    at org.skife.jdbi.v2.sqlobject.stringtemplate.ST4StatementLocator$STGroupFileWithThreadSafeLoading.lookupTemplate(ST4StatementLocator.java:343)
    at org.stringtemplate.v4.STGroup.getInstanceOf(STGroup.java:165)
    at org.skife.jdbi.v2.sqlobject.stringtemplate.ST4StatementLocator.locateAndRender(ST4StatementLocator.java:291)
    at org.skife.jdbi.v2.sqlobject.stringtemplate.ST4StatementLocator.locateFromCache(ST4StatementLocator.java:279)
    at org.skife.jdbi.v2.sqlobject.stringtemplate.ST4StatementLocator.locate(ST4StatementLocator.java:242)
    at org.skife.jdbi.v2.SQLStatement.wrapLookup(SQLStatement.java:1288)
    at org.skife.jdbi.v2.SQLStatement.internalExecute(SQLStatement.java:1297)
    at org.skife.jdbi.v2.Query.fold(Query.java:173)
    at org.skife.jdbi.v2.Query.first(Query.java:275)
    at org.skife.jdbi.v2.Query.first(Query.java:264)
    at org.skife.jdbi.v2.sqlobject.ResultReturnThing$SingleValueResultReturnThing.result(ResultReturnThing.java:112)
    at org.skife.jdbi.v2.sqlobject.ResultReturnThing.map(ResultReturnThing.java:48)
    at org.skife.jdbi.v2.sqlobject.QueryHandler.invoke(QueryHandler.java:45)
    at org.skife.jdbi.v2.sqlobject.SqlObject.invoke(SqlObject.java:180)
    at org.skife.jdbi.v2.sqlobject.SqlObject$1.intercept(SqlObject.java:76)
    at org.skife.jdbi.v2.sqlobject.CloseInternalDoNotUseThisClass$$EnhancerByCGLIB$$fa65c70f.getById(<generated>)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    ...
```