### PR TITLE
Fix: don't apply AttributeRenderer to text elements

### DIFF
--- a/contributors.txt
+++ b/contributors.txt
@@ -68,3 +68,4 @@ YYYY/MM/DD, github id, Full name, email
 2020/09/06, peteruhnak, Peter Uhnak, i.uhnak@gmail.com
 2020/09/16, Dvoreth, Jarmila Emanuela Panwitz, jaremapan@gmail.com
 2020/10/01, beccagaspard, Becca Gaspard, beccagaspard at gmail dot com
+2021/05/02, bannmann, Jens Bannmann, jens dot b at web dot de

--- a/doc/renderers.md
+++ b/doc/renderers.md
@@ -1,5 +1,7 @@
 # Attribute Renderers
 
+## Introduction
+
 The atomic element of a template is a simple attribute (object) that is rendered to text by its the appropriate string evaluation method for the port's language (toString, ToString, `_str_`, ...).
 For example, an integer object is converted to text as a sequence of characters representing the numeric value. 
 What if we want commas to separate the 1000's places like 1,000,000? 
@@ -15,7 +17,9 @@ public interface AttributeRenderer<T> {
     public String toString(T value, String formatString, Locale locale);
 }
 ```
- 
+
+## How ST invokes renderers 
+
 To render expression `<e>`, StringTemplate looks for a renderer associated with the object type of `e`, say, *t*. 
 If *t* is associated with a registered renderer, *r*, it is suitable and StringTemplate invokes the renderer method:
  
@@ -27,6 +31,7 @@ If *t* is associated with a registered renderer, *r*, it is suitable and StringT
 StringTemplate supplies either the default locale, or whatever locale was set by the programmer. 
 If the format string passed to the renderer is not recognized then the renderer should simply call the usual string evaluation method.
 
+## Renderer registration
 To register a renderer, we tell the group to associate an object type with a renderer object. 
 Here's an example that tells StringTemplate to render numbers with an instance of NumberRenderer using the Polish locale:
  
@@ -77,3 +82,9 @@ g.registerRenderer(String.class, new NumberRenderer()); // error
 ```
 
 StringTemplate comes with three predefined renderers: `DateRenderer`, `StringRenderer`, and `NumberRenderer`.
+
+## Interaction with Text Elements
+
+Strictly speaking, attribute renderers should only be applied to _attribute expressions_. However, the default behavior
+of StringTemplate is to also apply them to the _text elements_ contained in the template itself. Starting with
+StringTemplate 4.3.1, you can disable this by calling `setStrictRendering(true)` on `STGroup`.

--- a/doc/renderers.md
+++ b/doc/renderers.md
@@ -87,4 +87,4 @@ StringTemplate comes with three predefined renderers: `DateRenderer`, `StringRen
 
 Strictly speaking, attribute renderers should only be applied to _attribute expressions_. However, the default behavior
 of StringTemplate is to also apply them to the _text elements_ contained in the template itself. Starting with
-StringTemplate 4.3.1, you can disable this by calling `setStrictRendering(true)` on `STGroup`.
+StringTemplate 4.3.2, you can disable this by calling `setStrictRendering(true)` on `STGroup`.

--- a/src/org/stringtemplate/v4/Interpreter.java
+++ b/src/org/stringtemplate/v4/Interpreter.java
@@ -698,28 +698,10 @@ public class Interpreter {
     /** Write out a text element, i.e. a part of the template that is neither expression nor comment
      */
     protected int writeText(STWriter out, InstanceScope scope, String o) {
-        int start = out.index(); // track char we're about to write
-        int n = writeTextObject(out, scope, o);
-        if ( debug ) {
-            EvalExprEvent e = new EvalExprEvent(scope,
-                                                start, out.index() - 1,
-                                                getExprStartChar(scope),
-                                                getExprStopChar(scope));
-            trackDebugEvent(scope, e);
-        }
-        return n;
+        // By default, we pass text elements to attribute renderers. See STGroup.setStrictRendering() for details.
+        return writeObjectNoOptions(out, scope, o);
     }
-
-    protected int writeTextObject(STWriter out, InstanceScope scope, String v) {
-        try {
-            return out.write(v);
-        }
-        catch (IOException ioe) {
-            errMgr.IOError(scope.st, ErrorType.WRITE_IO_ERROR, ioe, v);
-            return 0;
-        }
-    }
-
+    
     /** Write out an expression result that uses expression options.
      *  E.g., {@code <names; separator=", ">}
      */

--- a/src/org/stringtemplate/v4/Interpreter.java
+++ b/src/org/stringtemplate/v4/Interpreter.java
@@ -451,7 +451,7 @@ public class Interpreter {
                     strIndex = getShort(code, ip);
                     ip += Bytecode.OPND_SIZE_IN_BYTES;
                     o = self.impl.strings[strIndex];
-                    n1 = writeObjectNoOptions(out, scope, o);
+                    n1 = writeText(out, scope, (String)o);
                     n += n1;
                     nwline += n1;
                     break;
@@ -693,6 +693,31 @@ public class Interpreter {
             trackDebugEvent(scope, e);
         }
         return n;
+    }
+
+    /** Write out a text element, i.e. a part of the template that is neither expression nor comment
+     */
+    protected int writeText(STWriter out, InstanceScope scope, String o) {
+        int start = out.index(); // track char we're about to write
+        int n = writeTextObject(out, scope, o);
+        if ( debug ) {
+            EvalExprEvent e = new EvalExprEvent(scope,
+                                                start, out.index() - 1,
+                                                getExprStartChar(scope),
+                                                getExprStopChar(scope));
+            trackDebugEvent(scope, e);
+        }
+        return n;
+    }
+
+    protected int writeTextObject(STWriter out, InstanceScope scope, String v) {
+        try {
+            return out.write(v);
+        }
+        catch (IOException ioe) {
+            errMgr.IOError(scope.st, ErrorType.WRITE_IO_ERROR, ioe, v);
+            return 0;
+        }
     }
 
     /** Write out an expression result that uses expression options.

--- a/src/org/stringtemplate/v4/ST.java
+++ b/src/org/stringtemplate/v4/ST.java
@@ -427,10 +427,19 @@ public class ST {
     }
 
     public int write(STWriter out, Locale locale) {
-        Interpreter interp = new Interpreter(groupThatCreatedThisInstance,
-                                             locale,
-                                             impl.nativeGroup.errMgr,
-                                             false);
+        Interpreter interp;
+        if ( groupThatCreatedThisInstance.strictRendering ) {
+            interp = new StrictInterpreter(groupThatCreatedThisInstance,
+                                           locale,
+                                           impl.nativeGroup.errMgr,
+                                           false);
+        }
+        else {
+            interp = new Interpreter(groupThatCreatedThisInstance,
+                                     locale,
+                                     impl.nativeGroup.errMgr,
+                                     false);
+        }
         InstanceScope scope = new InstanceScope(null, this);
         return interp.exec(out, scope);
     }
@@ -444,10 +453,19 @@ public class ST {
     }
 
     public int write(STWriter out, Locale locale, STErrorListener listener) {
-        Interpreter interp = new Interpreter(groupThatCreatedThisInstance,
-                                             locale,
-                                             new ErrorManager(listener),
-                                             false);
+        Interpreter interp;
+        if ( groupThatCreatedThisInstance.strictRendering ) {
+            interp = new StrictInterpreter(groupThatCreatedThisInstance,
+                                           locale,
+                                           new ErrorManager(listener),
+                                           false);
+        }
+        else {
+            interp = new Interpreter(groupThatCreatedThisInstance,
+                                     locale,
+                                     new ErrorManager(listener),
+                                     false);
+        }
         InstanceScope scope = new InstanceScope(null, this);
         return interp.exec(out, scope);
     }
@@ -524,8 +542,13 @@ public class ST {
         StringWriter out = new StringWriter();
         STWriter wr = new AutoIndentWriter(out);
         wr.setLineWidth(lineWidth);
-        Interpreter interp =
-            new Interpreter(groupThatCreatedThisInstance, locale, true);
+        Interpreter interp;
+        if ( groupThatCreatedThisInstance.strictRendering ) {
+            interp = new StrictInterpreter(groupThatCreatedThisInstance, locale, true);
+        }
+        else {
+            interp = new Interpreter(groupThatCreatedThisInstance, locale, true);
+        }
         InstanceScope scope = new InstanceScope(null, this);
         interp.exec(wr, scope); // render and track events
         List<InterpEvent> events = interp.getEvents();
@@ -549,8 +572,13 @@ public class ST {
         StringWriter out = new StringWriter();
         STWriter wr = new AutoIndentWriter(out);
         wr.setLineWidth(lineWidth);
-        Interpreter interp =
-            new Interpreter(groupThatCreatedThisInstance, locale, true);
+        Interpreter interp;
+        if ( groupThatCreatedThisInstance.strictRendering ) {
+            interp = new StrictInterpreter(groupThatCreatedThisInstance, locale, true);
+        }
+        else {
+            interp = new Interpreter(groupThatCreatedThisInstance, locale, true);
+        }
         InstanceScope scope = new InstanceScope(null, this);
         interp.exec(wr, scope); // render and track events
         return interp.getEvents();

--- a/src/org/stringtemplate/v4/STGroup.java
+++ b/src/org/stringtemplate/v4/STGroup.java
@@ -900,7 +900,7 @@ public class STGroup {
      * @param strictRendering {@code true} to render text elements directly,
      * {@code false} (the default) to apply attribute renderers.
      *
-     * @since 4.3.1
+     * @since 4.3.2
      */
     public void setStrictRendering(boolean strictRendering) {
         this.strictRendering = strictRendering;

--- a/src/org/stringtemplate/v4/STGroup.java
+++ b/src/org/stringtemplate/v4/STGroup.java
@@ -899,6 +899,8 @@ public class STGroup {
      *
      * @param strictRendering {@code true} to render text elements directly,
      * {@code false} (the default) to apply attribute renderers.
+     *
+     * @since 4.3.1
      */
     public void setStrictRendering(boolean strictRendering) {
         this.strictRendering = strictRendering;

--- a/src/org/stringtemplate/v4/STGroup.java
+++ b/src/org/stringtemplate/v4/STGroup.java
@@ -149,6 +149,8 @@ public class STGroup {
      */
     protected Map<Class<?>, AttributeRenderer<?>> renderers;
 
+    protected boolean strictRendering;
+
     /** A dictionary that allows people to register a model adaptor for
      *  a particular kind of object (subclass or implementation). Applies
      *  for any template evaluated relative to this group.
@@ -886,5 +888,19 @@ public class STGroup {
             }
         }
         return result;
+    }
+
+    /** Sets whether rendering of text elements should bypass attribute renderers.
+     * The default behavior of ST is to apply registered renderers (e.g.
+     * {@link StringRenderer}) not only to attribute expressions, but also to
+     * text elements. If you don't need backwards compatibility and your attribute
+     * renderers must not be applied to text elements, use this method to enable
+     * the new "strict rendering" mode.
+     *
+     * @param strictRendering {@code true} to render text elements directly,
+     * {@code false} (the default) to apply attribute renderers.
+     */
+    public void setStrictRendering(boolean strictRendering) {
+        this.strictRendering = strictRendering;
     }
 }

--- a/src/org/stringtemplate/v4/StrictInterpreter.java
+++ b/src/org/stringtemplate/v4/StrictInterpreter.java
@@ -1,0 +1,50 @@
+package org.stringtemplate.v4;
+
+import java.io.IOException;
+import java.util.Locale;
+
+import org.stringtemplate.v4.debug.EvalExprEvent;
+import org.stringtemplate.v4.misc.ErrorManager;
+import org.stringtemplate.v4.misc.ErrorType;
+
+public class StrictInterpreter extends Interpreter {
+    public StrictInterpreter(STGroup group, boolean debug) {
+        super(group, debug);
+    }
+
+    public StrictInterpreter(STGroup group, Locale locale, boolean debug) {
+        super(group, locale, debug);
+    }
+
+    public StrictInterpreter(STGroup group, ErrorManager errMgr, boolean debug) {
+        super(group, errMgr, debug);
+    }
+
+    public StrictInterpreter(STGroup group, Locale locale, ErrorManager errMgr, boolean debug) {
+        super(group, locale, errMgr, debug);
+    }
+
+    @Override
+    protected int writeText(STWriter out, InstanceScope scope, String o) {
+        int start = out.index(); // track char we're about to write
+        int n = writeTextObject(out, scope, o);
+        if ( debug ) {
+            EvalExprEvent e = new EvalExprEvent(scope,
+                                                start, out.index() - 1,
+                                                getExprStartChar(scope),
+                                                getExprStopChar(scope));
+            trackDebugEvent(scope, e);
+        }
+        return n;
+    }
+
+    protected int writeTextObject(STWriter out, InstanceScope scope, String v) {
+        try {
+            return out.write(v);
+        }
+        catch (IOException ioe) {
+            errMgr.IOError(scope.st, ErrorType.WRITE_IO_ERROR, ioe, v);
+            return 0;
+        }
+    }
+}

--- a/test/org/stringtemplate/v4/test/TestRenderers.java
+++ b/test/org/stringtemplate/v4/test/TestRenderers.java
@@ -294,12 +294,34 @@ public class TestRenderers extends BaseTest {
         assertEquals(expecting, result);
     }
 
-    @Test public void testStringRendererUsedOnlyForAttribute() throws Exception {
+    @Test public void testDefaultRenderingUsesAttributeRendererForText() throws Exception {
         String templates =
             "foo(x) ::= << begin <x> end >>\n";
 
         writeFile(tmpdir, "t.stg", templates);
         STGroup group = new STGroupFile(tmpdir+"/t.stg");
+
+        group.registerRenderer(String.class, new AttributeRenderer<String>() {
+            @Override
+            public String toString(String value, String formatString, Locale locale) {
+                return value.toUpperCase();
+            }
+        });
+
+        ST st = group.getInstanceOf("foo");
+        st.add("x", "attribute");
+        String expecting = " BEGIN ATTRIBUTE END ";
+        String result = st.render();
+        assertEquals(expecting, result);
+    }
+
+    @Test public void testStrictRenderingBypassesAttributeRendererForText() throws Exception {
+        String templates =
+            "foo(x) ::= << begin <x> end >>\n";
+
+        writeFile(tmpdir, "t.stg", templates);
+        STGroup group = new STGroupFile(tmpdir+"/t.stg");
+        group.setStrictRendering(true);
 
         group.registerRenderer(String.class, new AttributeRenderer<String>() {
             @Override

--- a/test/org/stringtemplate/v4/test/TestRenderers.java
+++ b/test/org/stringtemplate/v4/test/TestRenderers.java
@@ -35,7 +35,7 @@ import org.stringtemplate.v4.DateRenderer;
 import org.stringtemplate.v4.NumberRenderer;
 import org.stringtemplate.v4.ST;
 import org.stringtemplate.v4.STGroup;
-import org.stringtemplate.v4.STGroupFile;
+import org.stringtemplate.v4.STGroupString;
 import org.stringtemplate.v4.StringRenderer;
 
 import java.util.ArrayList;
@@ -70,8 +70,7 @@ public class TestRenderers extends BaseTest {
     @Test public void testRendererForGroup() throws Exception {
         String templates =
                 "dateThing(created) ::= \"datetime: <created>\"\n";
-        writeFile(tmpdir, "t.stg", templates);
-        STGroup group = new STGroupFile(tmpdir+"/t.stg");
+        STGroup group = new STGroupString(templates);
         group.registerRenderer(GregorianCalendar.class, new DateRenderer());
         ST st = group.getInstanceOf("dateThing");
         st.add("created", new GregorianCalendar(2005, 7 - 1, 5));
@@ -86,8 +85,7 @@ public class TestRenderers extends BaseTest {
     @Test public void testRendererWithFormat() throws Exception {
         String templates =
                 "dateThing(created) ::= << date: <created; format=\"yyyy.MM.dd\"> >>\n";
-        writeFile(tmpdir, "t.stg", templates);
-        STGroup group = new STGroupFile(tmpdir+"/t.stg");
+        STGroup group = new STGroupString(templates);
         group.registerRenderer(GregorianCalendar.class, new DateRenderer());
         ST st = group.getInstanceOf("dateThing");
         st.add("created", new GregorianCalendar(2005, 7 - 1, 5));
@@ -99,8 +97,7 @@ public class TestRenderers extends BaseTest {
     @Test public void testRendererWithPredefinedFormat() throws Exception {
         String templates =
                 "dateThing(created) ::= << datetime: <created; format=\"short\"> >>\n";
-        writeFile(tmpdir, "t.stg", templates);
-        STGroup group = new STGroupFile(tmpdir+"/t.stg");
+        STGroup group = new STGroupString(templates);
         group.registerRenderer(GregorianCalendar.class, new DateRenderer());
         ST st = group.getInstanceOf("dateThing");
         st.add("created", new GregorianCalendar(2005, 7 - 1, 5));
@@ -115,8 +112,7 @@ public class TestRenderers extends BaseTest {
     @Test public void testRendererWithPredefinedFormat2() throws Exception {
         String templates =
                 "dateThing(created) ::= << datetime: <created; format=\"full\"> >>\n";
-        writeFile(tmpdir, "t.stg", templates);
-        STGroup group = new STGroupFile(tmpdir+"/t.stg");
+        STGroup group = new STGroupString(templates);
         group.registerRenderer(GregorianCalendar.class, new DateRenderer());
         ST st = group.getInstanceOf("dateThing");
         TimeZone origTimeZone = TimeZone.getDefault();
@@ -141,8 +137,7 @@ public class TestRenderers extends BaseTest {
         String templates =
                 "dateThing(created) ::= << date: <created; format=\"date:medium\"> >>\n";
 
-        writeFile(tmpdir, "t.stg", templates);
-        STGroup group = new STGroupFile(tmpdir+"/t.stg");
+        STGroup group = new STGroupString(templates);
         group.registerRenderer(GregorianCalendar.class, new DateRenderer());
         ST st = group.getInstanceOf("dateThing");
         st.add("created", new GregorianCalendar(2005, 7 - 1, 5));
@@ -155,8 +150,7 @@ public class TestRenderers extends BaseTest {
         String templates =
                 "dateThing(created) ::= << time: <created; format=\"time:medium\"> >>\n";
 
-        writeFile(tmpdir, "t.stg", templates);
-        STGroup group = new STGroupFile(tmpdir+"/t.stg");
+        STGroup group = new STGroupString(templates);
         group.registerRenderer(GregorianCalendar.class, new DateRenderer());
         ST st = group.getInstanceOf("dateThing");
         st.add("created", new GregorianCalendar(2005, 7 - 1, 5));
@@ -169,8 +163,7 @@ public class TestRenderers extends BaseTest {
         String templates =
                 "foo(x) ::= << <x; format=\"cap\"> >>\n";
 
-        writeFile(tmpdir, "t.stg", templates);
-        STGroup group = new STGroupFile(tmpdir+"/t.stg");
+        STGroup group = new STGroupString(templates);
         group.registerRenderer(String.class, new StringRenderer());
         ST st = group.getInstanceOf("foo");
         st.add("x", "hi");
@@ -185,8 +178,7 @@ public class TestRenderers extends BaseTest {
                 "foo(x) ::= << <(t()); format=\"cap\"> >>\n" +
                 "t() ::= <<ack>>\n";
 
-        writeFile(tmpdir, "t.stg", templates);
-        STGroup group = new STGroupFile(tmpdir+"/t.stg");
+        STGroup group = new STGroupString(templates);
         group.registerRenderer(String.class, new StringRenderer());
         ST st = group.getInstanceOf("foo");
         st.add("x", "hi");
@@ -200,8 +192,7 @@ public class TestRenderers extends BaseTest {
                 "foo(x) ::= << <({ack}); format=\"cap\"> >>\n" +
                 "t() ::= <<ack>>\n";
 
-        writeFile(tmpdir, "t.stg", templates);
-        STGroup group = new STGroupFile(tmpdir+"/t.stg");
+        STGroup group = new STGroupString(templates);
         group.registerRenderer(String.class, new StringRenderer());
         ST st = group.getInstanceOf("foo");
         st.add("x", "hi");
@@ -214,8 +205,7 @@ public class TestRenderers extends BaseTest {
         String templates =
                 "foo(x) ::= << <x; format=\"cap\"> >>\n";
 
-        writeFile(tmpdir, "t.stg", templates);
-        STGroup group = new STGroupFile(tmpdir+"/t.stg");
+        STGroup group = new STGroupString(templates);
         group.registerRenderer(String.class, new StringRenderer());
         ST st = group.getInstanceOf("foo");
         st.add("x", "");
@@ -228,8 +218,7 @@ public class TestRenderers extends BaseTest {
         String templates =
                 "foo(x) ::= << <x; format=\"url-encode\"> >>\n";
 
-        writeFile(tmpdir, "t.stg", templates);
-        STGroup group = new STGroupFile(tmpdir+"/t.stg");
+        STGroup group = new STGroupString(templates);
         group.registerRenderer(String.class, new StringRenderer());
         ST st = group.getInstanceOf("foo");
         st.add("x", "a b");
@@ -242,8 +231,7 @@ public class TestRenderers extends BaseTest {
         String templates =
                 "foo(x) ::= << <x; format=\"xml-encode\"> >>\n";
 
-        writeFile(tmpdir, "t.stg", templates);
-        STGroup group = new STGroupFile(tmpdir+"/t.stg");
+        STGroup group = new STGroupString(templates);
         group.registerRenderer(String.class, new StringRenderer());
         ST st = group.getInstanceOf("foo");
         st.add("x", "a<b> &\t\b");
@@ -256,8 +244,7 @@ public class TestRenderers extends BaseTest {
         String templates =
                 "foo(x) ::= << <x; format=\"xml-encode\"> >>\n";
 
-        writeFile(tmpdir, "t.stg", templates);
-        STGroup group = new STGroupFile(tmpdir+"/t.stg");
+        STGroup group = new STGroupString(templates);
         group.registerRenderer(String.class, new StringRenderer());
         ST st = group.getInstanceOf("foo");
         st.add("x", null);
@@ -270,8 +257,7 @@ public class TestRenderers extends BaseTest {
         String templates =
             "foo(x) ::= << <x; format=\"xml-encode\"> >>\n";
 
-        writeFile(tmpdir, "t.stg", templates);
-        STGroup group = new STGroupFile(tmpdir+"/t.stg");
+        STGroup group = new STGroupString(templates);
         group.registerRenderer(String.class, new StringRenderer());
         ST st = group.getInstanceOf("foo");
         st.add("x", "\uD83E\uDE73");
@@ -284,8 +270,7 @@ public class TestRenderers extends BaseTest {
         String templates =
                 "foo(x) ::= << <x; format=\"%6s\"> >>\n";
 
-        writeFile(tmpdir, "t.stg", templates);
-        STGroup group = new STGroupFile(tmpdir+"/t.stg");
+        STGroup group = new STGroupString(templates);
         group.registerRenderer(String.class, new StringRenderer());
         ST st = group.getInstanceOf("foo");
         st.add("x", "hi");
@@ -298,8 +283,7 @@ public class TestRenderers extends BaseTest {
         String templates =
             "foo(x) ::= << begin <x> end >>\n";
 
-        writeFile(tmpdir, "t.stg", templates);
-        STGroup group = new STGroupFile(tmpdir+"/t.stg");
+        STGroup group = new STGroupString(templates);
 
         group.registerRenderer(String.class, new AttributeRenderer<String>() {
             @Override
@@ -319,8 +303,7 @@ public class TestRenderers extends BaseTest {
         String templates =
             "foo(x) ::= << begin <x> end >>\n";
 
-        writeFile(tmpdir, "t.stg", templates);
-        STGroup group = new STGroupFile(tmpdir+"/t.stg");
+        STGroup group = new STGroupString(templates);
         group.setStrictRendering(true);
 
         group.registerRenderer(String.class, new AttributeRenderer<String>() {
@@ -341,8 +324,7 @@ public class TestRenderers extends BaseTest {
         String templates =
                 "foo(x,y) ::= << <x; format=\"%d\"> <y; format=\"%2.3f\"> >>\n";
 
-        writeFile(tmpdir, "t.stg", templates);
-        STGroup group = new STGroupFile(tmpdir+"/t.stg");
+        STGroup group = new STGroupString(templates);
         group.registerRenderer(Integer.class, new NumberRenderer());
         group.registerRenderer(Double.class, new NumberRenderer());
         ST st = group.getInstanceOf("foo");
@@ -356,8 +338,7 @@ public class TestRenderers extends BaseTest {
     @Test public void testInstanceofRenderer() throws Exception {
         String templates =
                 "numberThing(x,y,z) ::= \"numbers: <x>, <y>; <z>\"\n";
-        writeFile(tmpdir, "t.stg", templates);
-        STGroup group = new STGroupFile(tmpdir+"/t.stg");
+        STGroup group = new STGroupString(templates);
         group.registerRenderer(Number.class, new NumberRenderer());
         ST st = group.getInstanceOf("numberThing");
         st.add("x", -2100);
@@ -374,8 +355,7 @@ public class TestRenderers extends BaseTest {
                 "<x; format=\"%,d\"> <y; format=\"%,2.3f\">\n" +
                 ">>\n";
 
-        writeFile(tmpdir, "t.stg", templates);
-        STGroup group = new STGroupFile(tmpdir+"/t.stg");
+        STGroup group = new STGroupString(templates);
         group.registerRenderer(Integer.class, new NumberRenderer());
         group.registerRenderer(Double.class, new NumberRenderer());
         ST st = group.getInstanceOf("foo");

--- a/test/org/stringtemplate/v4/test/TestRenderers.java
+++ b/test/org/stringtemplate/v4/test/TestRenderers.java
@@ -30,6 +30,7 @@ package org.stringtemplate.v4.test;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.stringtemplate.v4.AttributeRenderer;
 import org.stringtemplate.v4.DateRenderer;
 import org.stringtemplate.v4.NumberRenderer;
 import org.stringtemplate.v4.ST;
@@ -289,6 +290,27 @@ public class TestRenderers extends BaseTest {
         ST st = group.getInstanceOf("foo");
         st.add("x", "hi");
         String expecting = "     hi ";
+        String result = st.render();
+        assertEquals(expecting, result);
+    }
+
+    @Test public void testStringRendererUsedOnlyForAttribute() throws Exception {
+        String templates =
+            "foo(x) ::= << begin <x> end >>\n";
+
+        writeFile(tmpdir, "t.stg", templates);
+        STGroup group = new STGroupFile(tmpdir+"/t.stg");
+
+        group.registerRenderer(String.class, new AttributeRenderer<String>() {
+            @Override
+            public String toString(String value, String formatString, Locale locale) {
+                return value.toUpperCase();
+            }
+        });
+
+        ST st = group.getInstanceOf("foo");
+        st.add("x", "attribute");
+        String expecting = " begin ATTRIBUTE end ";
         String result = st.render();
         assertEquals(expecting, result);
     }


### PR DESCRIPTION
The [templates docs](https://github.com/antlr/stringtemplate4/blob/master/doc/templates.md) say:

> A template is a sequence of text and expression elements, optionally interspersed with comments.

However, if one registers an `AttributeRenderer<String>`, StringTemplate uses it not only for rendering attributes (_expression_ elements), but also for static text emitted by the template (_text_ elements).

This PR adds a unit test uncovering the problem and a (hopefully adequate) bugfix for the interpreter.

----
Background: for my project, I wrote an `AttributeRenderer<String>` that defaults to encoding XML/HTML entities even without an explicit `format=""` option in the attribute expression. The surprising effect was that the static HTML markup _around_ the attribute expressions was encoded as well and therefore no HTML tags being left in the output.