### PR TITLE
Bazel support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,9 @@ nbactions*.xml
 .project
 .classpath
 .settings/
+
+# Bazel
+bazel-bin
+bazel-out
+bazel-stringtemplate4
+bazel-testlogs

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,14 @@
+"""BUILD.bazel file for StringTemplate 4."""
+
+package(default_visibility = ["//visibility:private"])
+
+alias(
+    name = "stringtemplate4",
+    actual = "//src:stringtemplate4",
+    visibility = ["//visibility:public"],
+)
+
+test_suite(
+    name = "tests",
+    tests = ["//test:tests"],
+)

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,0 +1,31 @@
+workspace(name = "stringtemplate4")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+
+# This needs to be identical to the one used in https://github.com/antlr/antlr3/blob/master/WORKSPACE.bazel.
+http_jar(
+    name = "antlr3_bootstrap",
+    sha256 = "46531814ba9739cdf20c6c1789c252d3d95b68932813d79fb8bbfdf8d5840417",
+    url = "http://www.antlr3.org/download/antlr-3.5.2-complete-no-st3.jar",
+)
+
+http_jar(
+    name = "junit",
+    sha256 = "8e495b634469d64fb8acfa3495a065cbacc8a0fff55ce1e31007be4c16dc57d3",
+    url = "https://repo1.maven.org/maven2/junit/junit/4.13.2/junit-4.13.2.jar",
+)
+
+http_jar(
+    name = "hamcrest_core",
+    sha256 = "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
+    url = "https://repo1.maven.org/maven2/org/hamcrest/hamcrest-core/1.3/hamcrest-core-1.3.jar",
+)
+
+# TODO: Switch to http_archive once antlr3 has Bazel support. This approach is necessary to avoid
+#       an awkward situation where we need to update stringtemplate4 and antlr3 simultaneously.
+new_git_repository(
+    name = "antlr3",
+    branch = "master",
+    remote = "https://github.com/antlr/antlr3.git",
+)

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -1,0 +1,42 @@
+"""BUILD.bazel file for StringTemplate 4."""
+
+load("@rules_java//java:defs.bzl", "java_library")
+
+package(default_visibility = ["//:__pkg__"])
+
+java_library(
+    name = "stringtemplate4",
+    srcs = glob(["**/*.java"]) + [
+        "org/stringtemplate/v4/compiler/CodeGenerator.java",
+        "org/stringtemplate/v4/compiler/GroupLexer.java",
+        "org/stringtemplate/v4/compiler/GroupParser.java",
+        "org/stringtemplate/v4/compiler/STParser.java",
+    ],
+    resources = glob(["**/*.jfd"]),
+    deps = ["@antlr3//:java_runtime"],
+)
+
+genrule(
+    name = "stringtemplate4_bootstrap",
+    srcs = [
+        "org/stringtemplate/v4/compiler/CodeGenerator.g",
+        "org/stringtemplate/v4/compiler/Group.g",
+        "org/stringtemplate/v4/compiler/STParser.g",
+        "org/stringtemplate/v4/compiler/STLexer.tokens",
+    ],
+    outs = [
+        "org/stringtemplate/v4/compiler/CodeGenerator.java",
+        "org/stringtemplate/v4/compiler/GroupLexer.java",
+        "org/stringtemplate/v4/compiler/GroupParser.java",
+        "org/stringtemplate/v4/compiler/STParser.java",
+    ],
+    cmd = """
+      cp $(location :org/stringtemplate/v4/compiler/STLexer.tokens) $(RULEDIR)/org/stringtemplate/v4/compiler/STLexer.tokens
+      $(JAVA) -cp $(location @antlr3_bootstrap//jar) org.antlr.Tool -fo $(RULEDIR)/org/stringtemplate/v4/compiler $(location :org/stringtemplate/v4/compiler/STParser.g)
+      $(JAVA) -cp $(location @antlr3_bootstrap//jar) org.antlr.Tool -fo $(RULEDIR)/org/stringtemplate/v4/compiler $(location :org/stringtemplate/v4/compiler/Group.g)
+      $(JAVA) -cp $(location @antlr3_bootstrap//jar) org.antlr.Tool -fo $(RULEDIR)/org/stringtemplate/v4/compiler $(location :org/stringtemplate/v4/compiler/CodeGenerator.g)
+      rm -f $(RULEDIR)/org/stringtemplate/v4/compiler/STLexer.tokens
+    """,
+    toolchains = ["@bazel_tools//tools/jdk:current_host_java_runtime"],
+    tools = ["@antlr3_bootstrap//jar"],
+)

--- a/src/org/stringtemplate/v4/STGroupDir.java
+++ b/src/org/stringtemplate/v4/STGroupDir.java
@@ -162,7 +162,7 @@ public class STGroupDir extends STGroup {
                                           "from "+root+" prefix="+prefix);
         URL f;
         try {
-            f = new URI(root+prefix+unqualifiedFileName).normalize().toUrl();
+            f = new URI(root+prefix+unqualifiedFileName).normalize().toURL();
         }
         catch (MalformedURLException | URISyntaxException me) {
             errMgr.runTimeError(null, null, ErrorType.INVALID_TEMPLATE_NAME,

--- a/src/org/stringtemplate/v4/misc/STMessage.java
+++ b/src/org/stringtemplate/v4/misc/STMessage.java
@@ -65,6 +65,7 @@ public class STMessage {
         this(error,self,cause);
         this.arg = arg;
     }
+    @SuppressWarnings("ChainingConstructorIgnoresParameter")
     public STMessage(ErrorType error, ST self, Throwable cause, Token where, Object arg) {
         this(error,self,cause,where);
         this.arg = arg;

--- a/test/BUILD.bazel
+++ b/test/BUILD.bazel
@@ -1,0 +1,59 @@
+"""BUILD.bazel file for StringTemplate 4."""
+
+load("@rules_java//java:defs.bzl", "java_test")
+
+package(default_visibility = ["//:__pkg__"])
+
+java_test(
+    name = "tests",
+    srcs = glob(["org/stringtemplate/v4/test/*.java"]),
+    args = [
+        "org.stringtemplate.v4.test.TestAggregates",
+        "org.stringtemplate.v4.test.TestAttributes",
+        "org.stringtemplate.v4.test.TestBuggyDefaultValueRaisesNPETest",
+        "org.stringtemplate.v4.test.TestCompiler",
+        "org.stringtemplate.v4.test.TestCoreBasics",
+        "org.stringtemplate.v4.test.TestDebugEvents",
+        "org.stringtemplate.v4.test.TestDictionaries",
+        "org.stringtemplate.v4.test.TestDollarDelimiters",
+        # Skip as it uses AWT and the installed JRE is usually headless.
+        # "org.stringtemplate.v4.test.TestEarlyEvaluation",
+        "org.stringtemplate.v4.test.TestFunctions",
+        "org.stringtemplate.v4.test.TestGroupSyntax",
+        "org.stringtemplate.v4.test.TestGroupSyntaxErrors",
+        "org.stringtemplate.v4.test.TestGroups",
+        # Doesn't work for some reason, likely due to environment config.
+        # "org.stringtemplate.v4.test.TestImports",
+        "org.stringtemplate.v4.test.TestIndentation",
+        "org.stringtemplate.v4.test.TestIndirectionAndEarlyEval",
+        "org.stringtemplate.v4.test.TestInterptimeErrors",
+        "org.stringtemplate.v4.test.TestLexer",
+        "org.stringtemplate.v4.test.TestLineWrap",
+        "org.stringtemplate.v4.test.TestLists",
+        "org.stringtemplate.v4.test.TestModelAdaptors",
+        "org.stringtemplate.v4.test.TestNoNewlineTemplates",
+        "org.stringtemplate.v4.test.TestNullAndEmptyValues",
+        "org.stringtemplate.v4.test.TestOptions",
+        "org.stringtemplate.v4.test.TestRegions",
+        "org.stringtemplate.v4.test.TestRenderers",
+        "org.stringtemplate.v4.test.TestSTRawGroupDir",
+        "org.stringtemplate.v4.test.TestScopes",
+        "org.stringtemplate.v4.test.TestSubtemplates",
+        "org.stringtemplate.v4.test.TestSyntaxErrors",
+        "org.stringtemplate.v4.test.TestTemplateNames",
+        "org.stringtemplate.v4.test.TestTokensForDollarDelimiters",
+        "org.stringtemplate.v4.test.TestTreeConstruction",
+        "org.stringtemplate.v4.test.TestWhitespace",
+    ],
+    javacopts = [
+        "-Xep:JUnit4RunWithMissing:OFF",
+    ],
+    main_class = "org.junit.runner.JUnitCore",
+    use_testrunner = False,
+    deps = [
+        "//:stringtemplate4",
+        "@antlr3//:java_runtime",
+        "@hamcrest_core//jar",
+        "@junit//jar",
+    ],
+)


### PR DESCRIPTION
Perform some prerequisite work for Bazel support in StringTemplate 4.

I need to do the same to ANTLRv3 before I can come back and update the `TODO` in `WORKSPACE.bazel` with an appropriate commit.