### PR TITLE
Configure surefire to include test.jar in tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,21 +50,6 @@
 			<version>3.5.2</version>
 			<scope>compile</scope>
 		</dependency>
-        <!--
-         Include prepared jar so we can try to load templates from it; see TestGroupsFromCLASSPATH.java
-
-         Run:
-
-         mvn install:install-file -Dfile=test/test.jar -DgroupId=org.antlr -DartifactId=ST4-testjar -Dversion=1.0.0 -Dpackaging=jar
-
-         to install test jar in order to run tests
-         -->
-        <dependency>
-            <groupId>org.antlr</groupId>
-            <artifactId>ST4-testjar</artifactId>
-            <version>1.0.0</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 	<properties>
@@ -114,6 +99,11 @@
                 <version>2.22.0</version>
 				<configuration>
 					<argLine>-Dfile.encoding=UTF-8</argLine>
+					<additionalClasspathElements>
+						<!-- Include prepared jar so we can try to load templates from it;
+							see TestGroupsFromCLASSPATH.java -->
+						<additionalClasspathElement>test/test.jar</additionalClasspathElement>
+					</additionalClasspathElements>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
- Fixes #300

This needs no manual installation of test.jar to local repository.

Local results:
```
[WARNING] Tests run: 645, Failures: 0, Errors: 0, Skipped: 2
```

```
Test set: org.stringtemplate.v4.test.TestGroupsFromCLASSPATH
-------------------------------------------------------------------------------
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.011 s - in org.stringtemplate.v4.test.TestGroupsFromCLASSPATH
```

and its dependencies transit to client:
```
[INFO] |  \- org.seleniumhq.selenium:selenium-json:jar:4.1.3:compile
[INFO] +- org.antlr:ST4:jar:4.3.3-SNAPSHOT:compile
[INFO] |  \- org.antlr:antlr-runtime:jar:3.5.2:compile
[INFO] +- org.eclipse.jetty:jetty-server:jar:11.0.9:compile
```