### PR TITLE
Fixing typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@ ST (StringTemplate) is a java template engine (with ports for C#, Python, and Ob
 
 The main website is:
 
-> http://www.stringtemplate.org
+> https://www.stringtemplate.org
 
 Its distinguishing characteristic is that it strictly enforces
 model-view separation, unlike other engines. See:
 
-> http://www.cs.usfca.edu/~parrt/papers/mvc.templates.pdf
+> https://www.cs.usfca.edu/~parrt/papers/mvc.templates.pdf
 
 The documentation is in this repo
 
@@ -41,7 +41,7 @@ to the `<dependencies>` element in your **pom.xml** file.
 In `build.gradle`, add the following dependency:
 
 ```groovy
-dependecies {
+dependencies {
     // ...
 
     // https://mvnrepository.com/artifact/org.antlr/ST4

--- a/doc/groups.md
+++ b/doc/groups.md
@@ -73,7 +73,7 @@ The default and other mappings cannot have empty values. They have empty values 
 
 Dictionaries are defined in the group's scope and are visible if no attribute hides them. For example, if you define a formal argument called typeInitMap in template foo then foo cannot see the map defined in the group (though you could pass it in as another parameter). If a name is not an attribute and it's not in the group's maps table, then any imported groups are consulted. You may not redefine a dictionary and it may not have the same name as a template in that group. The default clause must be at the end of the map.
 
-You'll notice that square brackets denote data structure in other areas too such as `[a,b,c,...]` which makes a singe multi-valued attribute out of other attributes so you can iterate across them.
+You'll notice that square brackets denote data structure in other areas too such as `[a,b,c,...]` which makes a single multi-valued attribute out of other attributes so you can iterate across them.
 
 ## Template definitions
 

--- a/doc/introduction.md
+++ b/doc/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-First, to learn more about StringTemplate's philosophy, you can check out the very readable academic paper [Enforcing Strict Model-View Separation in Template Engines](http://www.cs.usfca.edu/~parrt/papers/mvc.templates.pdf) (*nominated for best paper at WWW2004*).
+First, to learn more about StringTemplate's philosophy, you can check out the very readable academic paper [Enforcing Strict Model-View Separation in Template Engines](https://www.cs.usfca.edu/~parrt/papers/mvc.templates.pdf) (*nominated for best paper at WWW2004*).
 
 Most programs that emit source code or other text output are unstructured blobs of generation logic interspersed with print statements. The primary reason is the lack of suitable tools and formalisms. The proper formalism is that of an output grammar because you are not generating random characters--you are generating sentences in an output language. This is analogous to using a grammar to describe the structure of input sentences. Rather than building a parser by hand, most programmers will use a parser generator. Similarly, we need some form of *unparser generator* to generate text. The most convenient manifestation of the output grammar is a template engine such as StringTemplate.
 
@@ -121,7 +121,7 @@ StringTemplate renders all injected attributes and any reference properties to t
 
 ### Injecting data aggregate attributes
 
-Being able to pass in objects and access their fields is very convenient but often we don't have a handy object to inject. Creating one-off data aggregates is a pain, you have to define a new class just to associate two pieces of data. StringTemplate makes it easy to group data during `add()` calls. You may pass in an aggregrate attribute name to `add()` with the data to aggregate. The syntax of the attribute name describes the properties. For example `a.{p1,p2,p3}` describes an attribute called a that has three properties `p1`, `p2`, `p3`. Here's an example:
+Being able to pass in objects and access their fields is very convenient but often we don't have a handy object to inject. Creating one-off data aggregates is a pain, you have to define a new class just to associate two pieces of data. StringTemplate makes it easy to group data during `add()` calls. You may pass in an aggregate attribute name to `add()` with the data to aggregate. The syntax of the attribute name describes the properties. For example `a.{p1,p2,p3}` describes an attribute called a that has three properties `p1`, `p2`, `p3`. Here's an example:
 
  
 ```java

--- a/doc/java.md
+++ b/doc/java.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-All you need to do is get the StringTemplate jar into your CLASSPATH as well as its dependent ANTLR jar. [Download Java StringTemplate 4.3.4 binary jar](http://www.stringtemplate.org/download.html) and put into your favorite lib directory such as `/usr/local/lib` on UNIX. Add to your CLASSPATH. On UNIX that looks like
+All you need to do is get the StringTemplate jar into your CLASSPATH as well as its dependent ANTLR jar. [Download Java StringTemplate 4.3.4 binary jar](https://www.stringtemplate.org/download.html) and put into your favorite lib directory such as `/usr/local/lib` on UNIX. Add to your CLASSPATH. On UNIX that looks like
  
 ```bash
 $ export CLASSPATH="/usr/local/lib/ST-4.3.4.jar:$CLASSPATH"
@@ -105,8 +105,8 @@ because it yields a file path to a jar and then inside:
 file:/somedirectory/AJARFILE.jar!/foo/main.stg
 ```
 
-This isn't a valid file system identifier. To use URL stuff, pass in a URL object not a string. See [Converting between URLs and Filesystem Paths](http://maven.apache.org/plugin-developers/common-bugs.html#Converting_between_URLs_and_Filesystem_Paths) for more information.
+This isn't a valid file system identifier. To use URL stuff, pass in a URL object not a string. See [Converting between URLs and Filesystem Paths](https://maven.apache.org/plugin-developers/common-bugs.html#Converting_between_URLs_and_Filesystem_Paths) for more information.
 
 ## API documentation
 
-[Java API](http://www.stringtemplate.org/api/index.html)
+[Java API](https://www.stringtemplate.org/api/index.html)

--- a/doc/motivation.md
+++ b/doc/motivation.md
@@ -17,7 +17,7 @@ Other benefits of model-view separation:
 
 ## Philosophy
 
-`StringTemplate` was born and evolved during the development of http://www.jGuru.com. The need for such dynamically-generated web pages has led to the development of numerous other template engines in an attempt to make web application development easier, improve flexibility, reduce maintenance costs, and allow parallel code and HTML development. These enticing benefits, which have driven the proliferation of template engines, **derive entirely from a single principle**: separating the specification of a page's business logic and data computations from the specification of how a page displays such information.
+`StringTemplate` was born and evolved during the development of https://www.jGuru.com. The need for such dynamically-generated web pages has led to the development of numerous other template engines in an attempt to make web application development easier, improve flexibility, reduce maintenance costs, and allow parallel code and HTML development. These enticing benefits, which have driven the proliferation of template engines, **derive entirely from a single principle**: separating the specification of a page's business logic and data computations from the specification of how a page displays such information.
 
 These template engines are in a sense a reaction to the completely entangled specifications encouraged by JSP (Java Server Pages), ASP (Active Server Pages) and, even ASP.NET. With separate encapsulated specifications, template engines promote component reuse, pluggable site "looks", single-points-of-change for common components, and high overall system clarity. In the code generation realm, model-view separation guarantees retargetability.
 
@@ -32,7 +32,7 @@ After examining hundreds of template files that I created over years of jGuru.co
 * conditional include of subtemplate (an IF statement); e.g., <if(title)><title><title></title><endif>
 * template application to list of attributes; e.g., <names:bold()> where template references can be recursive.
 
-Language theory supports my premise that even a minimal StringTemplate engine with only these features is very powerful--such an engine can generate the context-free languages; see [Enforcing Strict Model-View Separation in Template Engines](http://www.cs.usfca.edu/~parrt/papers/mvc.templates.pdf). E.g., most programming languages are context-free as are any XML pages whose form can be expressed with a DTD.
+Language theory supports my premise that even a minimal StringTemplate engine with only these features is very powerful--such an engine can generate the context-free languages; see [Enforcing Strict Model-View Separation in Template Engines](https://www.cs.usfca.edu/~parrt/papers/mvc.templates.pdf). E.g., most programming languages are context-free as are any XML pages whose form can be expressed with a DTD.
 
 While providing all sorts of dangerous features like assignment that promote the use of computations and logic in templates, many engines miss the key elements. Certain language semantics are absolutely required for generative programming and language translation. One is recursion. A template engine without recursion seems unlikely to be capable of generating recursive output structures such as nested tables or nested code blocks.
 

--- a/doc/regions.md
+++ b/doc/regions.md
@@ -50,7 +50,7 @@ Regions are like *subtemplates* scoped within a template, hence, the fully-quali
 
 Consider another problem where you would like, in a template subgroup, to replace a small portion of a large inherited template. Imagine you have a template that generates conditional statements in the output language, but you would also like to be able to generate a debug version of these statements which track the fact that an expression was evaluated.
 
-(To be clear about this example, ths template's purpose is to produce "if" statements in the output language, here Java. That "if" is unrelated to the issue of using template `<if(...)>` expressions, which we are discussing how to avoid.)
+(To be clear about this example, this template's purpose is to produce "if" statements in the output language, here Java. That "if" is unrelated to the issue of using template `<if(...)>` expressions, which we are discussing how to avoid.)
 
 Again, to avoid mingling debug version code with your main templates, you want to avoid "if dbg" type template expressions. Instead, mark the region within the template that might be replaced by an inheriting subgroup focusing on debugging. Here the code is marked with the pair of markers `<@eval>...<@end>`:
 

--- a/doc/releasing-st4.md
+++ b/doc/releasing-st4.md
@@ -139,7 +139,7 @@ and on the left click "Staging Repositories". You click the staging repo and clo
 
 All releases should be here: [https://repo1.maven.org/maven2/org/antlr/ST4/](https://repo1.maven.org/maven2/org/antlr/ST4/).
 
-Seems to take a while to propogate.
+Seems to take a while to propagate.
 
 ## Javadoc
 

--- a/doc/renderers.md
+++ b/doc/renderers.md
@@ -4,7 +4,7 @@ The atomic element of a template is a simple attribute (object) that is rendered
 For example, an integer object is converted to text as a sequence of characters representing the numeric value. 
 What if we want commas to separate the 1000's places like 1,000,000? 
 What if we want commas and sometimes periods depending on the locale? 
-For more, see [The Internationalization and Localization of Web Applications](http://www.cs.usfca.edu/~parrt/papers/i18n.pdf).
+For more, see [The Internationalization and Localization of Web Applications](https://www.cs.usfca.edu/~parrt/papers/i18n.pdf).
 
 StringTemplate lets you register objects that know how to format or otherwise render attributes to text appropriately.
 There is one registered renderer per type per group. 
@@ -51,7 +51,7 @@ Here's the renderer definition:
  *  Float, Double, and BigDecimal.  You pass in a format string suitable
  *  for Formatter object:
  *
- *  http://java.sun.com/j2se/1.5.0/docs/api/java/util/Formatter.html
+ *  https://docs.oracle.com/javase/1.5.0/docs/api/java/util/Formatter.html
  *
  *  For example, "%10d" emits a number as a decimal int padding to 10 char.
  *  This can even do long to date conversions using the format string.

--- a/doc/templates.md
+++ b/doc/templates.md
@@ -41,7 +41,7 @@ StringTemplate has the following literals.
 
 For more on list semantics, see [The real story on null vs empty](null-vs-empty.md).
 
-<a name="expresssions"></a>
+<a name="expressions"></a>
 ## Attribute expressions
 
 |Syntax|Description|

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <licenses>
 	    <license>
 		    <name>The BSD License</name>
-		    <url>http://www.antlr.org/license.html</url>
+		    <url>https://www.antlr.org/license.html</url>
 		    <distribution>repo</distribution>
 	    </license>
     </licenses>

--- a/src/org/stringtemplate/v4/compiler/CodeGenerator.g
+++ b/src/org/stringtemplate/v4/compiler/CodeGenerator.g
@@ -93,7 +93,7 @@ import org.stringtemplate.v4.*;
 		args.add(new FormalArgument(name));
 	}
 
-	// convience funcs to hide offensive sending of emit messages to
+	// convenience funcs to hide offensive sending of emit messages to
 	// CompilationState temp data object.
 
 	public void emit1(CommonTree opAST, short opcode, int arg) {

--- a/src/org/stringtemplate/v4/misc/Misc.java
+++ b/src/org/stringtemplate/v4/misc/Misc.java
@@ -178,7 +178,7 @@ public class Misc {
             try {
                 is.close();
             } catch (Throwable e) {
-                // Closing the input stream may throw an exception. See bug below. Most probabaly it was
+                // Closing the input stream may throw an exception. See bug below. Most probably it was
                 // the true reason for this commit: 
                 // https://github.com/antlr/stringtemplate4/commit/21484ed46f1b20b2cdaec49f9d5a626fb26a493c             
                 // https://bugs.openjdk.java.net/browse/JDK-8080094

--- a/test/org/stringtemplate/v4/test/BaseTest.java
+++ b/test/org/stringtemplate/v4/test/BaseTest.java
@@ -70,7 +70,7 @@ public abstract class BaseTest {
     public String tmpdir = null;
 
     /**
-     * When runnning from Maven, the junit tests are run via the surefire plugin. It sets the
+     * When running from Maven, the junit tests are run via the surefire plugin. It sets the
      * classpath for the test environment into the following property. We need to pick this up
      * for the junit tests that are going to generate and try to run code.
      */

--- a/test/org/stringtemplate/v4/test/TestEarlyEvaluation.java
+++ b/test/org/stringtemplate/v4/test/TestEarlyEvaluation.java
@@ -49,7 +49,7 @@ public class TestEarlyEvaluation extends BaseTest {
 
     /**
      * see
-     * http://www.antlr3.org/pipermail/stringtemplate-interest/2011-May/003476.html
+     * https://www.antlr3.org/pipermail/stringtemplate-interest/2011-May/003476.html
      *
      * @throws Exception
      */
@@ -81,7 +81,7 @@ public class TestEarlyEvaluation extends BaseTest {
 
     /**
      * see
-     * http://www.antlr.org/pipermail/stringtemplate-interest/2011-May/003476.html
+     * https://www.antlr.org/pipermail/stringtemplate-interest/2011-May/003476.html
      *
      * @throws Exception
      */
@@ -113,7 +113,7 @@ public class TestEarlyEvaluation extends BaseTest {
 
 
     /**
-     * see http://www.antlr3.org/pipermail/stringtemplate-interest/2011-August/003758.html
+     * see https://www.antlr3.org/pipermail/stringtemplate-interest/2011-August/003758.html
      * @throws Exception
      */
     @Test

--- a/test/org/stringtemplate/v4/test/TestGroupsFromCLASSPATH.java
+++ b/test/org/stringtemplate/v4/test/TestGroupsFromCLASSPATH.java
@@ -36,7 +36,7 @@ public class TestGroupsFromCLASSPATH extends BaseTest {
      * adding: jarbase/dir1/sample.st(in = 24) (out= 26)(deflated -8%)
      * adding: jarbase/testgroupfile.stg(in = 18) (out= 20)(deflated -11%)
      *
-     * I set it up so the jar is in the CLASSPATH and URL of gropu file should be this
+     * I set it up so the jar is in the CLASSPATH and URL of group file should be this
      * at runtime:
      *
      *  jar:file:/Users/parrt/antlr/code/stringtemplate4/test/test.jar!/jarbase/testgroupfile.stg


### PR DESCRIPTION
This PR fixes various typos found in the documentation and source files.
It also changes with various links from `http` to `https`.
